### PR TITLE
Feature/#7 login authorization

### DIFF
--- a/src/lib/axios/authInstance.ts
+++ b/src/lib/axios/authInstance.ts
@@ -1,0 +1,69 @@
+import { getCookie } from '@/utils/cookie';
+import axios, { AxiosError, AxiosInstance, InternalAxiosRequestConfig, AxiosResponse } from 'axios';
+
+import { onResponse } from './defaultInstance';
+
+const ACCESS_TOKEN_COOKIE_KEY = 'auth';
+const REFRESH_TOKEN_COOKIE_KEY = 'renew';
+const AXIOS_TIMEOUT_SECOND = 10000;
+
+const authInstance = axios.create({
+  baseURL: import.meta.env.VITE_API_UR,
+  timeout: AXIOS_TIMEOUT_SECOND,
+  headers: {
+    'Content-Type': 'application/json',
+    WithCredentials: true,
+  },
+});
+
+const onAuthRequest = (config: InternalAxiosRequestConfig): InternalAxiosRequestConfig => {
+  const axiosConfig = config;
+  const accessToken = getCookie(ACCESS_TOKEN_COOKIE_KEY);
+  axiosConfig.headers.Authorization = accessToken ? `Bearer ${accessToken}` : '';
+  return axiosConfig;
+};
+
+export const reissueAccessToken = async () => {
+  const refreshToken = getCookie(REFRESH_TOKEN_COOKIE_KEY);
+  authInstance.defaults.headers.Authorization = `Bearer ${refreshToken}`;
+  try {
+    await axios.post('/api/token');
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      const { status } = error.response as AxiosResponse;
+      switch (status) {
+        case 401:
+          console.log('your account is hijacked');
+          console.log('Please logout now');
+          // TODO: Logout 화면 구성 후 추가할 코드 : window.location.href = '/logout';
+          break;
+        case 403:
+          console.log('Refresh token is expired');
+          window.location.href = '/login';
+          break;
+        default:
+          break;
+      }
+    }
+  }
+};
+
+const onAuthErrorResponse = async (error: AxiosError | Error): Promise<AxiosError> => {
+  if (axios.isAxiosError(error)) {
+    const { response } = error;
+    const { status } = error.response as AxiosResponse;
+
+    if (response && status === 403) {
+      reissueAccessToken();
+    }
+  }
+  return Promise.reject(error);
+};
+
+const setupInterceptors = (instance: AxiosInstance): AxiosInstance => {
+  instance.interceptors.request.use(onAuthRequest, onAuthErrorResponse);
+  instance.interceptors.response.use(onResponse, onAuthErrorResponse);
+  return instance;
+};
+
+export const authInstanceWithInterceptors = setupInterceptors(authInstance);

--- a/src/lib/axios/defaultInstance.ts
+++ b/src/lib/axios/defaultInstance.ts
@@ -1,0 +1,27 @@
+import axios, { AxiosError, AxiosInstance, InternalAxiosRequestConfig, AxiosResponse } from 'axios';
+
+const defaultInstance = axios.create({
+  baseURL: import.meta.env.VITE_API_UR,
+  timeout: 10000,
+  headers: { 'Content-Type': 'application/json' },
+});
+
+const onRequest = (config: InternalAxiosRequestConfig): InternalAxiosRequestConfig => {
+  return config;
+};
+
+export const onResponse = (response: AxiosResponse): AxiosResponse => {
+  return response;
+};
+
+const onErrorResponse = async (error: AxiosError | Error): Promise<AxiosError> => {
+  return Promise.reject(error);
+};
+
+const setupInterceptors = (instance: AxiosInstance): AxiosInstance => {
+  instance.interceptors.request.use(onRequest, onErrorResponse);
+  instance.interceptors.response.use(onResponse, onErrorResponse);
+  return instance;
+};
+
+export const defaultInstanceWithInterceptors = setupInterceptors(defaultInstance);


### PR DESCRIPTION
## Issues
- Issue number : #7 

## Tasks Done 
- Axios의 Interceptor를 통해 HTTP Request와 Response를 가로채서 토큰 관련 로직을 추가했습니다.
  - 토큰을 사용하지 않는 HTTP Request와 Response에 대한 인스턴스인 `defaultInstanceWithInterceptor`를 생성했습니다.
  - 토큰을 사용한 HTTP Request와 Response에 대한 인스턴스인 `authInstanceWithInterceptor`를 생성했습니다.

## Description
- Util 폴더의 `getCookie` 메서드를 사용하여 Access Token과 Refresh Token을 가져왔습니다.
- `authInstance`를 생성할 때, instance header의 `withCredentials` 값을 `true`로 설정했습니다.
- HTTP Request의 콜백 함수인 `onAuthResponse`에서 Access Token 값의 유무를 확인했습니다.
  -  Access Token 값이 있을 경우, instance header의 `Authorization` 값을 `Bearer [Access Token]`로 설정했습니다.
  - 없을 경우, 빈 문자열 `''`로 설정했습니다.
- HTTP Error Response의 콜백 함수인 `onAuthErrorRespone`에서 에러 상태 코드가 `403`이 나올 경우, Access Token 재발급 API인 `reissueAccessToken`을 호출했습니다.
-  `reissueAccessToken` API에서 instance header의 `Authorization` 값을 `Bearer [Refresh Token]`으로 설정하고 `axios.post('/api/token')` Request을 보냈습니다.
  - `reissueAccessToken` API의 Response에 대한 에러 상태 코드가 `401`이 나올 경우, Refresh Token이 도용되었으므로 로그아웃 페이지로 이동하는 로직을 구현했습니다.
  - `reissueAccessToken` API의 Response에 대한 에러 상태 코드가 `403`이 나올 경우, Refresh Token이 만료되었으므로 로그인 페이지로 이동하는 로직을 구현했습니다.
