### PR TITLE
Refactor/#20 configs login logic

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -37,7 +37,7 @@ module.exports = {
         groups: ['builtin', 'external', 'internal', 'parent', 'sibling', 'index', 'object', 'type'],
         pathGroups: [
           {
-            pattern: '@/*',
+            pattern: '@/**',
             group: 'internal',
             position: 'after',
           },

--- a/src/components/BottomNavigationBar/index.tsx
+++ b/src/components/BottomNavigationBar/index.tsx
@@ -1,7 +1,7 @@
 import { NavLink } from 'react-router-dom';
 
 const NAVLINK_CLASS_VARIANTS = {
-  active: 'flex flex-col justify-center items-center text-teal-300',
+  active: 'flex flex-col justify-center items-center text-primary',
   inactive: 'flex flex-col justify-center items-center text-white',
 } as const;
 

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,7 +1,8 @@
-import { usePreviousPage } from '@/hooks/usePreviuosPage';
-import { loginStateAtom } from '@/stores/atoms/loginStateAtom';
 import { Link, useLocation } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
+
+import { usePreviousPage } from '@/hooks/usePreviuosPage';
+import { loginStateAtom } from '@/stores/atoms/loginStateAtom';
 
 const BACK_BUTTON_VISIBILITY = {
   true: 'invisible',

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,6 +1,7 @@
 import { Link, useLocation } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 
+import { ROUTE_PATH } from '@/constants/routePath';
 import { usePreviousPage } from '@/hooks/usePreviuosPage';
 import { loginStateAtom } from '@/stores/atoms/loginStateAtom';
 
@@ -23,15 +24,15 @@ export const Header = () => {
       >
         <img src="/assets/images/back-button.svg" alt="backButton" />
       </button>
-      <Link to="/">
+      <Link to={ROUTE_PATH.root}>
         <img src="/assets/images/logo.svg" alt="Logo" />
       </Link>
       {isLogin ? (
-        <Link to="/mypage">
+        <Link to={ROUTE_PATH.myPage}>
           <img src="/assets/images/user-icon.svg" alt="userIcon" />
         </Link>
       ) : (
-        <Link to="/login">
+        <Link to={ROUTE_PATH.login}>
           <img src="/assets/images/user-icon.svg" alt="userIcon" />
         </Link>
       )}

--- a/src/components/LoginButton/index.tsx
+++ b/src/components/LoginButton/index.tsx
@@ -5,8 +5,8 @@ type LoginButtonProps = {
 
 const BACKGROUND_COLOR_VARIANTS = {
   google: 'bg-white',
-  kakao: 'bg-amber-300',
-  naver: 'bg-green-500',
+  kakao: 'bg-kakao',
+  naver: 'bg-naver',
 } as const;
 
 export const LoginButton = (props: LoginButtonProps) => {
@@ -15,7 +15,7 @@ export const LoginButton = (props: LoginButtonProps) => {
   return (
     <a
       href={AUTH_URL}
-      className={`${BACKGROUND_COLOR_VARIANTS[platform]} flex flex-row justify-center items-center w-300 h-10 mb-5 rounded-md`}
+      className={`${BACKGROUND_COLOR_VARIANTS[platform]} flex flex-row justify-center items-center w-[300px] h-10 mb-5 rounded-md`}
     >
       <img src={iconURL} alt={`${platform} icon`} />
       <span className="ml-2.5 font-sans font-bold text-sm">{platform}로 시작하기</span>

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,1 @@
+export * from './path';

--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -1,0 +1,6 @@
+export const PATH = {
+  root: '/',
+  login: '/login',
+  callback: '/callback',
+  mypage: '/my-page',
+} as const;

--- a/src/constants/routePath.ts
+++ b/src/constants/routePath.ts
@@ -1,6 +1,6 @@
-export const PATH = {
+export const ROUTE_PATH = {
   root: '/',
   login: '/login',
   callback: '/callback',
-  mypage: '/my-page',
+  myPage: '/my-page',
 } as const;

--- a/src/lib/axios/authInstance.ts
+++ b/src/lib/axios/authInstance.ts
@@ -3,7 +3,7 @@ import axios from 'axios';
 const AXIOS_TIMEOUT_SECOND = 10000;
 
 export const authInstance = axios.create({
-  baseURL: import.meta.env.VITE_API_UR,
+  baseURL: import.meta.env.VITE_API_URL,
   timeout: AXIOS_TIMEOUT_SECOND,
   headers: {
     'Content-Type': 'application/json',

--- a/src/lib/axios/defaultInstance.ts
+++ b/src/lib/axios/defaultInstance.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosError, AxiosInstance, InternalAxiosRequestConfig, AxiosResponse } from 'axios';
 
 const defaultInstance = axios.create({
-  baseURL: import.meta.env.VITE_API_UR,
+  baseURL: import.meta.env.VITE_API_URL,
   timeout: 10000,
   headers: { 'Content-Type': 'application/json' },
 });

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -19,7 +19,7 @@ export const Login = () => {
   return (
     <div className="flex flex-col justify-center items-center my-52">
       <h1 className="mb-14">
-        <img src="/assets/logo.svg" alt="Logo" />
+        <img src="/assets/images/logo.svg" alt="Logo" />
       </h1>
       <h3 className="mb-9 font-sans text-sm font-normal text-white tracking-tight">
         로그인 후 플래너의 다양한 기능을 사용해보세요

--- a/src/pages/LoginLoading/index.tsx
+++ b/src/pages/LoginLoading/index.tsx
@@ -1,9 +1,10 @@
+import { useEffect } from 'react';
+import { useRecoilState, useSetRecoilState } from 'recoil';
+
 import { usePreviousPage } from '@/hooks/usePreviuosPage';
 import { accessTokenAtom } from '@/stores/atoms/accessTokenAtom';
 import { loginStateAtom } from '@/stores/atoms/loginStateAtom';
 import { getCookie } from '@/utils/cookie';
-import { useEffect } from 'react';
-import { useRecoilState, useSetRecoilState } from 'recoil';
 
 const ACCESS_TOKEN_COOKIE_KEY = 'auth';
 const PREVIOUS_PAGE_NUMBER = -2;

--- a/src/pages/Root/index.tsx
+++ b/src/pages/Root/index.tsx
@@ -1,6 +1,7 @@
+import { Outlet } from 'react-router-dom';
+
 import { BottomNavigationBar } from '@/components/BottomNavigationBar';
 import { Header } from '@/components/Header';
-import { Outlet } from 'react-router-dom';
 
 export const Root = () => {
   return (

--- a/src/utils/reissueAccessToken.ts
+++ b/src/utils/reissueAccessToken.ts
@@ -1,18 +1,14 @@
 import axios, { AxiosResponse } from 'axios';
 
 import { authInstance } from '@/lib/axios/authInstance';
-import { getCookie } from '@/utils/cookie';
 
-const REFRESH_TOKEN_COOKIE_KEY = 'renew';
 const REISSUE_TOKEN_PATH = '/api/token';
 
 export const reissueAccessToken = async () => {
-  const refreshToken = getCookie(REFRESH_TOKEN_COOKIE_KEY);
-  authInstance.defaults.headers.Authorization = `Bearer ${refreshToken}`;
   try {
     const {
       data: { accessToken: newAccessToken },
-    } = await axios.post(REISSUE_TOKEN_PATH);
+    } = await authInstance.post(REISSUE_TOKEN_PATH);
     return newAccessToken;
   } catch (error) {
     if (axios.isAxiosError(error)) {

--- a/src/utils/reissueAccessToken.ts
+++ b/src/utils/reissueAccessToken.ts
@@ -1,6 +1,7 @@
+import axios, { AxiosResponse } from 'axios';
+
 import { authInstance } from '@/lib/axios/authInstance';
 import { getCookie } from '@/utils/cookie';
-import axios, { AxiosResponse } from 'axios';
 
 const REFRESH_TOKEN_COOKIE_KEY = 'renew';
 const REISSUE_TOKEN_PATH = '/api/token';

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -6,16 +6,16 @@ module.exports = {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {
-      color: {
-        naverColor: '00BF18',
+      colors: {
+        naver: '#00BF18',
+        kakao: '#FBE950',
+        primary: '#60EBD1',
       },
       fontFamily: {
         sans: ['Inter var', ...defaultTheme.fontFamily.sans],
       },
       spacing: {
         mobileHeight: '844px',
-        18: '18px',
-        300: '300px',
       },
     },
   },


### PR DESCRIPTION
## Issues
- Issue number #20 

## Tasks Done 
- [X] Tailwind CSS Config 파일 수정
  - [X] theme>extend>color를 theme>extend>colors로 고침
  - [X] primary color 추가
  - [X] 커스텀 색 이름인 naverColor, kakaoColor를 naver, kakao로 변경함
  - [X] spacing에서 안 쓰는 18, 300 속성 삭제
- [X] ESLint Config 파일 수정
  - [X] import/order에서 pathGroups가 적용 안 되는 문제 해결 (pattern: '@/*' => '@/**')
- [X] typo 수정
  - [X] Login Logo 이미지의 src 경로 알맞게 변경(경로에 image 폴더를 포함시킴)
  - [X] typo in Base URL of Axios Instance
- [X] 로그인 로직 수정
  - [X] Routing Path를 constant 폴더에서 상수로 선언
  - [X] reissueAccessToken 로직에서 refresh Token 접근 로직 삭제

## Description
- TailwindCSS Config 파일을 변경했습니다.
  - 오타로 인해 커스텀 color 설정이 적용되지 않은 부분을 해결했습니다.
  - 프로젝트의 메인 color '#60EBD1'를 **primary**로 설정했습니다.
  - 커스텀 color인 naverColor와 kakaoColor 이름에서 Color의 접미사가 불필요하다고 생각되어 **naver**, **kakao**로 변경했습니다.
- ESLintConfig 파일을 수정했습니다.
  - import/order rule에서 설정한 순서가 모든 internal import 문에 적용되지 않는 문제가 발생했습니다.
  - 그 원인은 internal에 대한 pattern `@/*` 이 src 폴더에서 1 depth까지의 경로에 해당하는 import 문에만 적용되기 때문이었습니다.
  - internal에 대한 pattern을  `@/*`에서  `@/**`으로 수정하여 src 폴더의 하위 폴더에 대한 모든 internal import 문에 설정한 순서가 적용되도록 했습니다.
- Axios Instance (defaultInstance, authInstance)의 baseURL에 오타가 있었습니다.
  - Base URL의 값을 `import.meta.env.VITE_API_UR` 을 `import.meta.env.VITE_API_URL`로 수정했습니다.
- 로그인 로직 관련된 파일을 수정했습니다.
  - Route의 path들을 constant 파일에 객체로 선언하여 사용하는 것으로 변경했습니다.
  - reissueAccessToken에서 Refresh Token에 접근하고 Authorization Header에 설정하는 로직을 삭제했습니다.
    - 그 이유는 Refresh Token은 **httponly** cookie에 저장되어 있으므로 JavaScript 코드로 접근할 수 없기 때문입니다.