### PR TITLE
Feat/#47 modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <div id="portal-root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/components/Modal/ModalButton.tsx
+++ b/src/components/Modal/ModalButton.tsx
@@ -1,31 +1,21 @@
-import { useRef, useLayoutEffect } from 'react';
-
-import type { RefObject } from 'react';
-
 type ModalButtonProps = {
   text: string;
   handler: () => void;
   imageUrl?: string;
-  isFocused?: boolean;
+  isPrimary?: boolean;
 };
 
-export const ModalButton = ({ text, handler, imageUrl, isFocused }: ModalButtonProps) => {
-  const buttonRef = useRef<HTMLButtonElement>() as RefObject<HTMLButtonElement>;
-  useLayoutEffect(() => {
-    if (isFocused && buttonRef.current) {
-      buttonRef.current.focus();
-    }
-  }, [isFocused]);
+export const ModalButton = ({ text, handler, imageUrl, isPrimary }: ModalButtonProps) => {
+  const primaryButtonStyle = isPrimary ? 'bg-primary text-black' : 'bg-[#373737] text-white';
 
   return (
     <button
       type="button"
-      className="flex h-14 w-20 cursor-pointer flex-col items-center justify-center gap-y-0.5 rounded-md bg-[#373737] focus:bg-primary focus:text-black"
+      className={`${primaryButtonStyle} flex min-h-[2.5rem] min-w-[3.75rem] items-center justify-center gap-y-0.5 rounded-md bg-[#373737] p-2`}
       onClick={handler}
-      ref={buttonRef}
     >
-      {imageUrl && <img src={imageUrl} alt="emoticon" className="h-5 w-5" />}
-      <span className="inline-block text-sm">{text}</span>
+      {imageUrl && <img src={imageUrl} alt="emoticon" className="mr-1.5 h-5 w-5" />}
+      <span className="inline-block text-xs">{text}</span>
     </button>
   );
 };

--- a/src/components/Modal/ModalButton.tsx
+++ b/src/components/Modal/ModalButton.tsx
@@ -1,0 +1,30 @@
+import { useRef, useLayoutEffect } from 'react';
+
+import type { RefObject } from 'react';
+
+type ModalButtonProps = {
+  text: string;
+  handler: () => void;
+  imageUrl?: string;
+  isFocused?: boolean;
+};
+
+export const ModalButton = ({ text, handler, imageUrl, isFocused }: ModalButtonProps) => {
+  const buttonRef = useRef<HTMLButtonElement>() as RefObject<HTMLButtonElement>;
+  useLayoutEffect(() => {
+    if (isFocused && buttonRef.current) {
+      buttonRef.current.focus();
+    }
+  }, [isFocused]);
+  return (
+    <button
+      type="button"
+      className="flex h-14 w-20 cursor-pointer flex-col items-center justify-center gap-y-0.5 rounded-md bg-[#373737] focus:bg-primary focus:text-black"
+      onClick={handler}
+      ref={buttonRef}
+    >
+      {imageUrl && <img src={imageUrl} alt="emoticon" className="h-5 w-5" />}
+      <span className="inline-block text-sm">{text}</span>
+    </button>
+  );
+};

--- a/src/components/Modal/ModalButton.tsx
+++ b/src/components/Modal/ModalButton.tsx
@@ -16,6 +16,7 @@ export const ModalButton = ({ text, handler, imageUrl, isFocused }: ModalButtonP
       buttonRef.current.focus();
     }
   }, [isFocused]);
+
   return (
     <button
       type="button"

--- a/src/components/Modal/ModalText.tsx
+++ b/src/components/Modal/ModalText.tsx
@@ -14,5 +14,5 @@ export const MainText = ({ children, textStyle }: TextProps) => {
 };
 
 export const SubText = ({ children, textStyle }: TextProps) => {
-  return <p className={`${textStyle} mb-0.5 text-sm leading-6`}>{children}</p>;
+  return <p className={`${textStyle} text-sm leading-6`}>{children}</p>;
 };

--- a/src/components/Modal/ModalText.tsx
+++ b/src/components/Modal/ModalText.tsx
@@ -1,0 +1,18 @@
+import { ReactNode } from 'react';
+
+type TextProps = {
+  children: ReactNode;
+  textStyle?: string;
+};
+
+export const PromptText = ({ children, textStyle = '' }: TextProps) => {
+  return <div className={`${textStyle}`}>{children}</div>;
+};
+
+export const MainText = ({ children, textStyle }: TextProps) => {
+  return <p className={`${textStyle} mb-4 text-base font-extrabold`}>{children}</p>;
+};
+
+export const SubText = ({ children, textStyle }: TextProps) => {
+  return <p className={`${textStyle} mb-0.5 text-sm`}>{children}</p>;
+};

--- a/src/components/Modal/ModalText.tsx
+++ b/src/components/Modal/ModalText.tsx
@@ -14,5 +14,5 @@ export const MainText = ({ children, textStyle }: TextProps) => {
 };
 
 export const SubText = ({ children, textStyle }: TextProps) => {
-  return <p className={`${textStyle} mb-0.5 text-sm`}>{children}</p>;
+  return <p className={`${textStyle} mb-0.5 text-sm leading-6`}>{children}</p>;
 };

--- a/src/components/Modal/ModalText.tsx
+++ b/src/components/Modal/ModalText.tsx
@@ -5,7 +5,7 @@ type TextProps = {
   textStyle?: string;
 };
 
-export const PromptText = ({ children, textStyle = '' }: TextProps) => {
+export const ModalText = ({ children, textStyle = '' }: TextProps) => {
   return <div className={`${textStyle}`}>{children}</div>;
 };
 

--- a/src/components/Modal/ModalText.tsx
+++ b/src/components/Modal/ModalText.tsx
@@ -6,7 +6,7 @@ type TextProps = {
 };
 
 export const ModalText = ({ children, textStyle = '' }: TextProps) => {
-  return <div className={`${textStyle}`}>{children}</div>;
+  return <div className={`${textStyle} max-w-[20rem]`}>{children}</div>;
 };
 
 export const MainText = ({ children, textStyle }: TextProps) => {

--- a/src/components/Modal/PromptText.tsx
+++ b/src/components/Modal/PromptText.tsx
@@ -5,5 +5,5 @@ type PromptTextProps = {
 };
 
 export const PromptText = ({ children }: PromptTextProps) => {
-  return <div className="whitespace-normal text-center">{children}</div>;
+  return <span className="text-center">{children}</span>;
 };

--- a/src/components/Modal/PromptText.tsx
+++ b/src/components/Modal/PromptText.tsx
@@ -1,9 +1,0 @@
-import { ReactNode } from 'react';
-
-type PromptTextProps = {
-  children: ReactNode;
-};
-
-export const PromptText = ({ children }: PromptTextProps) => {
-  return <span className="text-center">{children}</span>;
-};

--- a/src/components/Modal/PromptText.tsx
+++ b/src/components/Modal/PromptText.tsx
@@ -1,0 +1,9 @@
+import { ReactNode } from 'react';
+
+type PromptTextProps = {
+  children: ReactNode;
+};
+
+export const PromptText = ({ children }: PromptTextProps) => {
+  return <div className="whitespace-normal text-center">{children}</div>;
+};

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -9,7 +9,7 @@ type ModalProps = {
 export const Modal = ({ children }: ModalProps) => {
   return createPortal(
     <div className="fixed left-0 top-0 z-50 flex h-screen w-screen items-center justify-center">
-      <div className="flex h-[100%] w-[100%] items-center justify-center sm:h-[50rem] sm:max-h-[90vh] sm:w-96">
+      <div className="flex h-[100%] w-[100%] items-center justify-center bg-black/50 sm:h-[50rem] sm:max-h-[90vh] sm:w-96">
         <div className="z-50 flex h-40 w-[21.375rem] flex-col items-center justify-center rounded-md bg-[#202020] p-5">
           {children}
         </div>

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -10,7 +10,7 @@ export const Modal = ({ children }: ModalProps) => {
   return createPortal(
     <div className="fixed left-0 top-0 z-50 flex h-screen w-screen items-center justify-center">
       <div className="flex h-[100%] w-[100%] items-center justify-center bg-black/50 sm:h-[50rem] sm:max-h-[90vh] sm:w-96">
-        <div className="z-50 flex flex-col items-center justify-center rounded-md bg-[#202020] p-5">
+        <div className="z-50 flex flex-col items-center justify-center overflow-hidden rounded-md bg-[#202020]">
           {children}
         </div>
       </div>

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -1,0 +1,20 @@
+import { createPortal } from 'react-dom';
+
+import type { ReactNode } from 'react';
+
+type ModalProps = {
+  children: ReactNode;
+};
+
+export const Modal = ({ children }: ModalProps) => {
+  return createPortal(
+    <div className="fixed left-0 top-0 z-50 flex h-screen w-screen items-center justify-center">
+      <div className="flex h-[100%] w-[100%] items-center justify-center sm:h-[50rem] sm:max-h-[90vh] sm:w-96">
+        <div className="z-50 flex h-40 w-[21.375rem] flex-col items-center justify-center rounded-md bg-[#202020] p-5">
+          {children}
+        </div>
+      </div>
+    </div>,
+    document.getElementById('portal-root') as HTMLElement,
+  );
+};

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -10,7 +10,7 @@ export const Modal = ({ children }: ModalProps) => {
   return createPortal(
     <div className="fixed left-0 top-0 z-50 flex h-screen w-screen items-center justify-center">
       <div className="flex h-[100%] w-[100%] items-center justify-center bg-black/50 sm:h-[50rem] sm:max-h-[90vh] sm:w-96">
-        <div className="z-50 flex h-40 w-[21.375rem] flex-col items-center justify-center rounded-md bg-[#202020] p-5">
+        <div className="z-50 flex flex-col items-center justify-center rounded-md bg-[#202020] p-5">
           {children}
         </div>
       </div>

--- a/src/constants/routePath.ts
+++ b/src/constants/routePath.ts
@@ -17,4 +17,5 @@ export const ROUTE_PATH = {
   },
   summary: '/summary',
   community: '/community',
+  withdrawal: '/withdrawal',
 } as const;

--- a/src/constants/routePath.ts
+++ b/src/constants/routePath.ts
@@ -17,5 +17,5 @@ export const ROUTE_PATH = {
   },
   summary: '/summary',
   community: '/community',
-  withdrawal: '/withdrawal',
+  deleteAccount: '/delete-account',
 } as const;

--- a/src/pages/EditMyPage/index.tsx
+++ b/src/pages/EditMyPage/index.tsx
@@ -37,7 +37,7 @@ export const EditMyPage = () => {
   };
 
   const handleOkButtonClick = () => {
-    navigate(ROUTE_PATH.withdrawal);
+    navigate(ROUTE_PATH.deleteAccount);
   };
 
   const handleCancleButtonClick = () => {

--- a/src/pages/EditMyPage/index.tsx
+++ b/src/pages/EditMyPage/index.tsx
@@ -37,7 +37,7 @@ export const EditMyPage = () => {
   };
 
   const handleOkButtonClick = () => {
-    navigate('/withdrawal');
+    navigate(ROUTE_PATH.withdrawal);
   };
 
   const handleCancleButtonClick = () => {

--- a/src/pages/EditMyPage/index.tsx
+++ b/src/pages/EditMyPage/index.tsx
@@ -70,7 +70,7 @@ export const EditMyPage = () => {
               회원 탈퇴시 Pullanner의 모든 데이터가 삭제됩니다. 삭제된 데이터는 복구할 수 없습니다.
             </SubText>
           </ModalText>
-          <div className="flex w-full justify-around p-3">
+          <div className="mb-2 flex w-full justify-around p-3">
             <ModalButton
               text="네"
               handler={handleOkButtonClick}

--- a/src/pages/EditMyPage/index.tsx
+++ b/src/pages/EditMyPage/index.tsx
@@ -7,7 +7,7 @@ import { SaveButton } from '@/components/buttons/SaveButton';
 import { DuplicationCheckForm } from '@/components/DuplicationCheckForm';
 import { Modal } from '@/components/Modal';
 import { ModalButton } from '@/components/Modal/ModalButton';
-import { MainText, SubText, PromptText } from '@/components/Modal/ModalText';
+import { MainText, SubText, ModalText } from '@/components/Modal/ModalText';
 import { ROUTE_PATH } from '@/constants';
 import { useMutateNickname } from '@/lib/react-query/useUserData';
 
@@ -64,11 +64,12 @@ export const EditMyPage = () => {
       <DimmedButton name="회원탈퇴" handler={handleWithdrwalButtonClick} />
       {showModal && (
         <Modal>
-          <PromptText textStyle="p-5">
+          <ModalText textStyle="p-5">
             <MainText textStyle="text-red-400">정말 탈퇴하시겠습니까?</MainText>
-            <SubText>회원 탈퇴시 Pullanner의 모든 데이터가 삭제됩니다.</SubText>
-            <SubText>삭제된 데이터는 복구할 수 없습니다.</SubText>
-          </PromptText>
+            <SubText>
+              회원 탈퇴시 Pullanner의 모든 데이터가 삭제됩니다. 삭제된 데이터는 복구할 수 없습니다.
+            </SubText>
+          </ModalText>
           <div className="flex w-full justify-around p-3">
             <ModalButton
               text="네"

--- a/src/pages/EditMyPage/index.tsx
+++ b/src/pages/EditMyPage/index.tsx
@@ -7,7 +7,7 @@ import { SaveButton } from '@/components/buttons/SaveButton';
 import { DuplicationCheckForm } from '@/components/DuplicationCheckForm';
 import { Modal } from '@/components/Modal';
 import { ModalButton } from '@/components/Modal/ModalButton';
-import { PromptText } from '@/components/Modal/PromptText';
+import { MainText, SubText, PromptText } from '@/components/Modal/ModalText';
 import { ROUTE_PATH } from '@/constants';
 import { useMutateNickname } from '@/lib/react-query/useUserData';
 
@@ -64,14 +64,12 @@ export const EditMyPage = () => {
       <DimmedButton name="회원탈퇴" handler={handleWithdrwalButtonClick} />
       {showModal && (
         <Modal>
-          <PromptText>
-            <p className="mb-2.5 text-xs">
-              회원 탈퇴시 Pullanner의<span className="font-extrabold">모든 데이터가 삭제</span>
-              됩니다.
-            </p>
-            <p className="text-xs">정말 탈퇴하시겠습니까?</p>
+          <PromptText textStyle="p-5">
+            <MainText textStyle="text-red-400">정말 탈퇴하시겠습니까?</MainText>
+            <SubText>회원 탈퇴시 Pullanner의 모든 데이터가 삭제됩니다.</SubText>
+            <SubText>삭제된 데이터는 복구할 수 없습니다.</SubText>
           </PromptText>
-          <div className="mt-4 flex w-full justify-around">
+          <div className="flex w-full justify-around p-3">
             <ModalButton
               text="네"
               handler={handleOkButtonClick}
@@ -81,7 +79,7 @@ export const EditMyPage = () => {
               text="아니오"
               handler={handleCancleButtonClick}
               imageUrl="/assets/images/emotion/5.svg"
-              isFocused
+              isPrimary
             />
           </div>
         </Modal>

--- a/src/pages/EditMyPage/index.tsx
+++ b/src/pages/EditMyPage/index.tsx
@@ -5,6 +5,9 @@ import { validateNickname } from '@/apis/user';
 import { DimmedButton } from '@/components/buttons/DimmedButton';
 import { SaveButton } from '@/components/buttons/SaveButton';
 import { DuplicationCheckForm } from '@/components/DuplicationCheckForm';
+import { Modal } from '@/components/Modal';
+import { ModalButton } from '@/components/Modal/ModalButton';
+import { PromptText } from '@/components/Modal/PromptText';
 import { ROUTE_PATH } from '@/constants';
 import { useMutateNickname } from '@/lib/react-query/useUserData';
 
@@ -18,6 +21,7 @@ export const EditMyPage = () => {
     state: { nickname },
   } = useLocation();
   const [nicknameValue, setNicknameValue] = useState(nickname);
+  const [showModal, setShowModal] = useState(false);
   const { mutate } = useMutateNickname();
   const navigate = useNavigate();
 
@@ -26,6 +30,18 @@ export const EditMyPage = () => {
       mutate(nicknameValue);
       navigate(ROUTE_PATH.myPage.index);
     }
+  };
+
+  const handleWithdrwalButtonClick = () => {
+    setShowModal(true);
+  };
+
+  const handleOkButtonClick = () => {
+    navigate('/withdrawal');
+  };
+
+  const handleCancleButtonClick = () => {
+    setShowModal(false);
   };
 
   return (
@@ -45,7 +61,31 @@ export const EditMyPage = () => {
         />
       </div>
 
-      <DimmedButton name="회원탈퇴" />
+      <DimmedButton name="회원탈퇴" handler={handleWithdrwalButtonClick} />
+      {showModal && (
+        <Modal>
+          <PromptText>
+            <p className="mb-2.5 text-xs">
+              회원 탈퇴시 Pullanner의<span className="font-extrabold">모든 데이터가 삭제</span>
+              됩니다.
+            </p>
+            <p className="text-xs">정말 탈퇴하시겠습니까?</p>
+          </PromptText>
+          <div className="mt-4 flex w-full justify-around">
+            <ModalButton
+              text="네"
+              handler={handleOkButtonClick}
+              imageUrl="/assets/images/emotion/2.svg"
+            />
+            <ModalButton
+              text="아니오"
+              handler={handleCancleButtonClick}
+              imageUrl="/assets/images/emotion/5.svg"
+              isFocused
+            />
+          </div>
+        </Modal>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Issues
- Issue number #47 

## Tasks Done 
- [x] **createPortal** API를 사용하여 `Modal` 컴포넌트 구현
- [x] `Modal` 컴포넌트 안에 들어갈 `Modal Button`, `Prompt Text` 컴포넌트 구현

## Description
- 형식이 정해진 라이브러리를 사용하는 대신 React의 **createPortal** API를 사용하여 범용적인 Modal 컴포넌트를 구현했습니다.
  - `Modal` 컴포넌트의 **children** props를 받아서 자식 컴포넌트들을 합성하여 사용할 수 있도록 했습니다.
  - `Modal` 컴포넌트의 배경 컴포넌트의 **opacity**로 0.5를 적용했습니다.
  - `Modal` 컴포넌트의 자식 컴포넌트들에게 border-radius가 적용되도록 **overflow**로 hidden을 적용했습니다.
  - "네" 버튼 클릭 시 이동하는 경로를 `/delete-account`로 수정했습니다.
- `ModalButton` 컴포넌트를 구현했습니다.
  - **text**, **handler** props를 받아서 여러 버튼 컴포넌트로 재사용할 수 있도록 구현했습니다.
  - **imageUrl** props를 받을 경우, `ModalButton` 컴포넌트의 자식 컴포넌트로 **img** 요소를 렌더링하도록 했습니다.
  - **isPrimary** props의 값으로 true를 받을 경우, `ModalButton` 컴포넌트의 배경색이 메인색이 되도록 했습니다.
  - `ModalButton` 컴포넌트에 **min-height**로 40px(2.5rem) , **min-width**로 60px(3.75rem), **padding**로 8px(p-2)을 설정했습니다.
- `ModalText` 컴포넌트를 구현했습니다.
  - `ModalText` 컴포넌트의 **children** props를 받아서 자식 컴포넌트들을 합성하여 사용할 수 있도록 했습니다.
  - `ModalText` 컴포넌트에 **max-width**로 320px(20rem)을 설정했습니다.
  - `MainText` 컴포넌트에 **font-size**로 16px(text-base), **font-weight**로 800(font-extrabold)를 설정했습니다.
  - `SubText` 컴포넌트에  **font-size**로 14px(text-sm), **line-height**로 24px(leading-6)를 설정했습니다.

## Visuals

<img width="213" alt="스크린샷 2023-07-21 131535" src="https://github.com/Pullanner/pullanner-web/assets/70058081/8d003f97-b6c1-45ca-a9c6-04014d907e31">

