### PR TITLE
Fix/#74 duplication check input

### DIFF
--- a/src/components/DuplicationCheckInput/index.tsx
+++ b/src/components/DuplicationCheckInput/index.tsx
@@ -53,6 +53,9 @@ export const DuplicationCheckInput = ({
 
   const handleDuplicationCheckButtonClick = async () => {
     try {
+      if (duplicationCheckButtonState === BUTTON_STATE.inactive) {
+        return;
+      }
       const isInputNotDuplicated = await validationFunction(
         inputValue,
         accessToken,

--- a/src/components/DuplicationCheckInput/index.tsx
+++ b/src/components/DuplicationCheckInput/index.tsx
@@ -52,12 +52,13 @@ export const DuplicationCheckInput = ({
   };
 
   const handleDuplicationCheckButtonClick = async () => {
-    try {
-      if (duplicationCheckButtonState === BUTTON_STATE.inactive) {
-        setInputValue('');
+    if (duplicationCheckButtonState === BUTTON_STATE.inactive) {
+      setInputValue('');
 
-        return;
-      }
+      return;
+    }
+
+    try {
       const isInputNotDuplicated = await validationFunction(
         inputValue,
         accessToken,

--- a/src/components/DuplicationCheckInput/index.tsx
+++ b/src/components/DuplicationCheckInput/index.tsx
@@ -54,6 +54,8 @@ export const DuplicationCheckInput = ({
   const handleDuplicationCheckButtonClick = async () => {
     try {
       if (duplicationCheckButtonState === BUTTON_STATE.inactive) {
+        setInputValue('');
+
         return;
       }
       const isInputNotDuplicated = await validationFunction(

--- a/src/components/DuplicationCheckInput/index.tsx
+++ b/src/components/DuplicationCheckInput/index.tsx
@@ -21,6 +21,11 @@ type DuplicationCheckInputProps = {
   validationFunction: AsyncValidateFunction;
 };
 
+const BUTTON_STATE = {
+  active: 'active',
+  inactive: 'inactive',
+} as const;
+
 export const DuplicationCheckInput = ({
   inputName,
   defaultValue = '',
@@ -33,7 +38,8 @@ export const DuplicationCheckInput = ({
   const [inputStatus, setInputStatus] = useState<InputStatusType>(INVALID_INPUT.status);
   const [showValidationResult, setValidationResultShowed] = useState(false);
   const [accessToken, setAccessToken] = useAtom(accessTokenAtom);
-  const DuplicationCheckButtonState = inputValue.length >= minLength ? 'active' : 'inactive';
+  const duplicationCheckButtonState =
+    inputValue.length >= minLength ? BUTTON_STATE.active : BUTTON_STATE.inactive;
   let isFirstTyping = true;
 
   const handleInputChange = ({ target: { value } }: ChangeEvent<HTMLInputElement>) => {
@@ -84,7 +90,7 @@ export const DuplicationCheckInput = ({
         />
         <button
           type="button"
-          className={`h-[1.875rem] w-[4.875rem] rounded-[0.313rem] text-base ${DUPLICATION_CHECK_BUTTON_STYLE[DuplicationCheckButtonState]}`}
+          className={`h-[1.875rem] w-[4.875rem] rounded-[0.313rem] text-base ${DUPLICATION_CHECK_BUTTON_STYLE[duplicationCheckButtonState]}`}
           onClick={handleDuplicationCheckButtonClick}
         >
           중복확인

--- a/src/components/DuplicationCheckInput/index.tsx
+++ b/src/components/DuplicationCheckInput/index.tsx
@@ -77,7 +77,7 @@ export const DuplicationCheckInput = ({
   };
 
   return (
-    <div className="flex flex-col">
+    <div className="flex w-full flex-col">
       <label className="mb-2.5 inline-block text-sm" htmlFor={inputName}>
         {inputName}
       </label>


### PR DESCRIPTION
## Issues
- Issue number #74
- Issue number #75 

## Tasks Done 
- [x] **duplicationButtonState** 버튼 상태를 상수(`BUTTON_STATE`)로 선언
- [x] `DuplicationCheckInput`에서 input value가 최소 길이가 아닐 때,  **duplicationButtonState** 버튼 핸들러 콜백 함수에서 early return하는 로직 추가
- [x]  **duplicationButtonState** 버튼이 비활성화 상태일 때, input value에 빈 문자열을 넣어서 **저장** 또는 **다음으로 가기** 버튼 비활성화하는 로직 추가
- [x] 디자인 수정을 반영하여 `DuplicationCheckInput`의 **width**를 100%로 수정

## Description
- **"중복 확인"** 버튼 상태에 따른 조건부 로직을 구현하기 위해, **"중복 확인"** 버튼 상태를 상수로 정의했습니다.
- nickname이 없는 경우에도 **"중복 확인"** 버튼이 클릭되는 버그를 수정했습니다.
- **"중복 확인"** 버튼을 누르지 않았을 때도 **"저장"** 또는 **""다음으로 가기"** 버튼이 클릭되는 버그를 수정했습니다.
- 바뀐 디자인을 반영하여  `DuplicationCheckInput`의 **width**를 100%로 수정했습니다.
