### PR TITLE
[#77] Fix: modify the type of isActive to boolean

### DIFF
--- a/src/components/buttons/SaveButton/index.tsx
+++ b/src/components/buttons/SaveButton/index.tsx
@@ -1,5 +1,5 @@
 type SaveButtonProps = {
-  isActive: 'active' | 'inactive';
+  isActive: boolean;
   handleButtonClick: () => void;
   width: string;
   height: string;

--- a/src/pages/EditMyPage/index.tsx
+++ b/src/pages/EditMyPage/index.tsx
@@ -58,7 +58,7 @@ export const EditMyPage = () => {
     <div>
       <div className="flex w-full flex-row-reverse py-5">
         <SaveButton
-          isActive={nicknameValue.length ? 'active' : 'inactive'}
+          isActive={!!nicknameValue.length}
           handleButtonClick={handleSaveButtonClick}
           width="5rem"
           height="2rem"


### PR DESCRIPTION
## Issues
- Issue number #77 

## Tasks Done 
- [x] **isActive** property를 boolean 타입으로 변경함
- [x] `EditMyPage`의 `SaveButton`에 변경 내용을 적용함

## Description
- **isActive** property 값이 `'active' | 'inactive'`이기 때문에, 두 문자열 모두 **truthy**값이므로 **opacity**가 1이 되서 항상 활성화 상태가 되어 있었습니다.
- **isActive** property를 **boolean** 타입으로 변경하여 문제를 해결했습니다.
- `EditMyPage`에서 `SaveButton`의 **isActive** property 값을 `!!nicknameValue.length`로 수정했습니다.

## Visuals
- before
<img width="193" alt="스크린샷 2023-08-07 141440" src="https://github.com/Pullanner/pullanner-web/assets/70058081/26968eba-95a1-4b95-b698-e37a9114b746">

- after
<img width="192" alt="스크린샷 2023-08-07 141809" src="https://github.com/Pullanner/pullanner-web/assets/70058081/c76b6e11-491d-484f-b733-977b4c09ee73">
