### PR TITLE
[#80] Refactor: add loginState to conditional logic to move to SetNickname page

### DIFF
--- a/src/pages/Root/index.tsx
+++ b/src/pages/Root/index.tsx
@@ -7,12 +7,14 @@ import { ScrollTopButton } from '@/components/buttons/ScrollTopButton';
 import { Header } from '@/components/Header';
 import { ROUTE_PATH } from '@/constants';
 import { accessTokenAtom } from '@/stores/atoms/accessTokenAtom';
+import { loginStateAtom } from '@/stores/atoms/loginStateAtom';
 import { userDataAtom, UserData } from '@/stores/atoms/userDataAtom';
 import { initializeAccessToken } from '@/utils/initializeAccessToken';
 
 export const Root = () => {
   const [accessToken, setAccessToken] = useAtom(accessTokenAtom);
   const userData = useAtomValue(userDataAtom) as UserData;
+  const loginState = useAtomValue(loginStateAtom);
   const navigate = useNavigate();
   const isProductionMode = import.meta.env.PROD;
 
@@ -23,10 +25,10 @@ export const Root = () => {
   }, [isProductionMode, accessToken, setAccessToken]);
 
   useEffect(() => {
-    if (!userData?.nickname) {
+    if (loginState && !userData?.nickname) {
       navigate(ROUTE_PATH.setup.setNickname);
     }
-  }, [userData, navigate]);
+  }, [loginState, userData?.nickname, navigate]);
 
   return (
     <div className="flex h-screen w-screen flex-row items-center justify-center">


### PR DESCRIPTION
## Issues
- Issue number #80 

## Tasks Done 
- [x] `SetNickname` 페이지로 이동하는 조건부 로직에 **loginState** 상태 추가하기

## Description
- 사이트에 처음 들어왔을 때, 로그인도 하기 전에 `SetNickname` 페이지로 이동하는 버그가 발생했습니다.
  - `SetNickname` 페이지로 이동하는 조건부 로직이 `!UserData?.nickname`으로 되어 있으므로, 로그인 여부와 상관 없이 UserData의 **nickname**이 없을 때  `SetNickname` 페이지로 이동하기 때문이었습니다.
  - `SetNickname` 페이지로 이동하는 조건부 로직에 **loginState** 상태 추가도 추가하여, 로그인 상태이면서 UserData의 **nickname**이 없을 경우에면 `SetNickname` 페이지로 이동하도록 수정했습니다.
