### PR TITLE
Fix/#84 배포 환경에서 발생한 문제들 해결

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -13,7 +13,7 @@ const BACK_BUTTON_VISIBILITY = {
 export const Header = () => {
   const location = useLocation();
   const isMainPage = location.pathname === ROUTE_PATH.roadmap.index ? 'true' : 'false';
-  const isLogin = useAtomValue(loginStateAtom);
+  const isLogin = useAtomValue(loginStateAtom) as boolean;
   const handleBackButtonClick = usePreviousPage();
 
   return (

--- a/src/pages/LoginLoading/index.tsx
+++ b/src/pages/LoginLoading/index.tsx
@@ -1,4 +1,4 @@
-import { useAtom, useAtomValue, useSetAtom } from 'jotai';
+import { useAtom, useSetAtom } from 'jotai';
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
@@ -6,7 +6,7 @@ import { ROUTE_PATH } from '@/constants/routePath';
 import { useUserData } from '@/lib/react-query/useUserData';
 import { accessTokenAtom } from '@/stores/atoms/accessTokenAtom';
 import { loginStateAtom } from '@/stores/atoms/loginStateAtom';
-import { userDataAtom, UserData } from '@/stores/atoms/userDataAtom';
+import { userDataAtom } from '@/stores/atoms/userDataAtom';
 import { getCookie } from '@/utils/cookie';
 
 const ACCESS_TOKEN_COOKIE_KEY = 'auth';
@@ -14,7 +14,6 @@ const ACCESS_TOKEN_COOKIE_KEY = 'auth';
 export const LoginLoading = () => {
   const [accessToken, setAccessToken] = useAtom(accessTokenAtom);
   const setLoginState = useSetAtom(loginStateAtom);
-  const userData = useAtomValue(userDataAtom) as UserData;
   const setUserData = useSetAtom(userDataAtom);
   const { data, isSuccess } = useUserData(accessToken, setAccessToken);
   const navigate = useNavigate();
@@ -29,11 +28,11 @@ export const LoginLoading = () => {
 
     if (isSuccess) {
       setUserData(data);
-      if (!userData?.nickname) {
+      if (!data.nickname) {
         navigate(ROUTE_PATH.setup.setNickname);
       }
     }
-  }, [setAccessToken, setLoginState, navigate, userData?.nickname, data, isSuccess, setUserData]);
+  }, [setAccessToken, setLoginState, navigate, data, isSuccess, setUserData]);
 
   return <div className="text-xl">Loading...</div>;
 };

--- a/src/pages/LoginLoading/index.tsx
+++ b/src/pages/LoginLoading/index.tsx
@@ -1,8 +1,9 @@
-import { useAtomValue, useSetAtom } from 'jotai';
+import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { ROUTE_PATH } from '@/constants/routePath';
+import { useUserData } from '@/lib/react-query/useUserData';
 import { accessTokenAtom } from '@/stores/atoms/accessTokenAtom';
 import { loginStateAtom } from '@/stores/atoms/loginStateAtom';
 import { userDataAtom, UserData } from '@/stores/atoms/userDataAtom';
@@ -11,9 +12,11 @@ import { getCookie } from '@/utils/cookie';
 const ACCESS_TOKEN_COOKIE_KEY = 'auth';
 
 export const LoginLoading = () => {
-  const setAccessToken = useSetAtom(accessTokenAtom);
+  const [accessToken, setAccessToken] = useAtom(accessTokenAtom);
   const setLoginState = useSetAtom(loginStateAtom);
   const userData = useAtomValue(userDataAtom) as UserData;
+  const setUserData = useSetAtom(userDataAtom);
+  const { data, isSuccess } = useUserData(accessToken, setAccessToken);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -24,10 +27,13 @@ export const LoginLoading = () => {
       navigate(ROUTE_PATH.roadmap.index);
     }
 
-    if (!userData?.nickname) {
-      navigate(ROUTE_PATH.setup.setNickname);
+    if (isSuccess) {
+      setUserData(data);
+      if (!userData?.nickname) {
+        navigate(ROUTE_PATH.setup.setNickname);
+      }
     }
-  }, [setAccessToken, setLoginState, navigate, userData?.nickname]);
+  }, [setAccessToken, setLoginState, navigate, userData?.nickname, data, isSuccess, setUserData]);
 
   return <div className="text-xl">Loading...</div>;
 };

--- a/src/pages/LoginLoading/index.tsx
+++ b/src/pages/LoginLoading/index.tsx
@@ -1,10 +1,11 @@
-import { useSetAtom } from 'jotai';
+import { useAtomValue, useSetAtom } from 'jotai';
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { ROUTE_PATH } from '@/constants/routePath';
 import { accessTokenAtom } from '@/stores/atoms/accessTokenAtom';
 import { loginStateAtom } from '@/stores/atoms/loginStateAtom';
+import { userDataAtom, UserData } from '@/stores/atoms/userDataAtom';
 import { getCookie } from '@/utils/cookie';
 
 const ACCESS_TOKEN_COOKIE_KEY = 'auth';
@@ -12,6 +13,7 @@ const ACCESS_TOKEN_COOKIE_KEY = 'auth';
 export const LoginLoading = () => {
   const setAccessToken = useSetAtom(accessTokenAtom);
   const setLoginState = useSetAtom(loginStateAtom);
+  const userData = useAtomValue(userDataAtom) as UserData;
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -21,7 +23,11 @@ export const LoginLoading = () => {
       setLoginState(true);
       navigate(ROUTE_PATH.roadmap.index);
     }
-  }, [setAccessToken, setLoginState, navigate]);
+
+    if (!userData?.nickname) {
+      navigate(ROUTE_PATH.setup.setNickname);
+    }
+  }, [setAccessToken, setLoginState, navigate, userData?.nickname]);
 
   return <div className="text-xl">Loading...</div>;
 };

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -1,11 +1,9 @@
-import { useAtom, useSetAtom, useAtomValue } from 'jotai';
-import { useEffect } from 'react';
+import { useSetAtom, useAtomValue } from 'jotai';
 import { useNavigate } from 'react-router-dom';
 
 import { DimmedButton } from '@/components/buttons/DimmedButton';
 import { API_PATH, ROUTE_PATH } from '@/constants';
 import { axiosInstance } from '@/lib/axios/instance';
-import { useUserData } from '@/lib/react-query/useUserData';
 import { accessTokenAtom } from '@/stores/atoms/accessTokenAtom';
 import { loginStateAtom } from '@/stores/atoms/loginStateAtom';
 import { userDataAtom, UserData } from '@/stores/atoms/userDataAtom';
@@ -15,18 +13,10 @@ import { TabSection } from './TabSection';
 import { UserSection } from './UserSection';
 
 export const MyPage = () => {
-  const [accessToken, setAccessToken] = useAtom(accessTokenAtom);
-  const { data, isSuccess } = useUserData(accessToken, setAccessToken);
+  const setAccessToken = useSetAtom(accessTokenAtom);
   const setLoginState = useSetAtom(loginStateAtom);
   const userData = useAtomValue(userDataAtom) as UserData;
-  const setUserData = useSetAtom(userDataAtom);
   const navigate = useNavigate();
-
-  useEffect(() => {
-    if (isSuccess) {
-      setUserData(data);
-    }
-  }, [isSuccess, data, setUserData]);
 
   const handleLogoutButtonClick = () => {
     axiosInstance.delete(API_PATH.token);

--- a/src/pages/Root/index.tsx
+++ b/src/pages/Root/index.tsx
@@ -10,7 +10,7 @@ import { initializeAccessToken } from '@/utils/initializeAccessToken';
 
 export const Root = () => {
   const [accessToken, setAccessToken] = useAtom(accessTokenAtom);
-  const loginState = useAtomValue(loginStateAtom);
+  const loginState = useAtomValue(loginStateAtom) as boolean;
   const isProductionMode = import.meta.env.PROD;
 
   if (isProductionMode && loginState && !accessToken.length) {

--- a/src/pages/Root/index.tsx
+++ b/src/pages/Root/index.tsx
@@ -1,4 +1,5 @@
 import { useAtom, useAtomValue } from 'jotai';
+import { useEffect } from 'react';
 import { Outlet } from 'react-router-dom';
 
 import { BottomNavigationBar } from '@/components/BottomNavigationBar';
@@ -13,9 +14,11 @@ export const Root = () => {
   const loginState = useAtomValue(loginStateAtom) as boolean;
   const isProductionMode = import.meta.env.PROD;
 
-  if (isProductionMode && loginState && !accessToken.length) {
-    initializeAccessToken(setAccessToken);
-  }
+  useEffect(() => {
+    if (isProductionMode && loginState && !accessToken.length) {
+      initializeAccessToken(setAccessToken);
+    }
+  }, [isProductionMode, loginState, accessToken, setAccessToken]);
 
   return (
     <div className="flex h-screen w-screen flex-row items-center justify-center">

--- a/src/pages/Root/index.tsx
+++ b/src/pages/Root/index.tsx
@@ -19,10 +19,10 @@ export const Root = () => {
   const isProductionMode = import.meta.env.PROD;
 
   useLayoutEffect(() => {
-    if (isProductionMode) {
+    if (isProductionMode && loginState) {
       initializeAccessToken(accessToken, setAccessToken);
     }
-  }, [isProductionMode, accessToken, setAccessToken]);
+  }, [isProductionMode, accessToken, setAccessToken, loginState]);
 
   useEffect(() => {
     if (loginState && !userData?.nickname) {

--- a/src/pages/Root/index.tsx
+++ b/src/pages/Root/index.tsx
@@ -1,5 +1,4 @@
 import { useAtom, useAtomValue } from 'jotai';
-import { useLayoutEffect, useEffect } from 'react';
 import { Outlet, useNavigate } from 'react-router-dom';
 
 import { BottomNavigationBar } from '@/components/BottomNavigationBar';
@@ -18,17 +17,13 @@ export const Root = () => {
   const navigate = useNavigate();
   const isProductionMode = import.meta.env.PROD;
 
-  useLayoutEffect(() => {
-    if (isProductionMode && loginState && !accessToken.length) {
-      initializeAccessToken(setAccessToken);
-    }
-  }, [isProductionMode, accessToken, setAccessToken, loginState]);
+  if (isProductionMode && loginState && !accessToken.length) {
+    initializeAccessToken(setAccessToken);
+  }
 
-  useEffect(() => {
-    if (loginState && !userData?.nickname) {
-      navigate(ROUTE_PATH.setup.setNickname);
-    }
-  }, [loginState, userData?.nickname, navigate]);
+  if (loginState && !userData?.nickname) {
+    navigate(ROUTE_PATH.setup.setNickname);
+  }
 
   return (
     <div className="flex h-screen w-screen flex-row items-center justify-center">

--- a/src/pages/Root/index.tsx
+++ b/src/pages/Root/index.tsx
@@ -1,28 +1,20 @@
 import { useAtom, useAtomValue } from 'jotai';
-import { Outlet, useNavigate } from 'react-router-dom';
+import { Outlet } from 'react-router-dom';
 
 import { BottomNavigationBar } from '@/components/BottomNavigationBar';
 import { ScrollTopButton } from '@/components/buttons/ScrollTopButton';
 import { Header } from '@/components/Header';
-import { ROUTE_PATH } from '@/constants';
 import { accessTokenAtom } from '@/stores/atoms/accessTokenAtom';
 import { loginStateAtom } from '@/stores/atoms/loginStateAtom';
-import { userDataAtom, UserData } from '@/stores/atoms/userDataAtom';
 import { initializeAccessToken } from '@/utils/initializeAccessToken';
 
 export const Root = () => {
   const [accessToken, setAccessToken] = useAtom(accessTokenAtom);
-  const userData = useAtomValue(userDataAtom) as UserData;
   const loginState = useAtomValue(loginStateAtom);
-  const navigate = useNavigate();
   const isProductionMode = import.meta.env.PROD;
 
   if (isProductionMode && loginState && !accessToken.length) {
     initializeAccessToken(setAccessToken);
-  }
-
-  if (loginState && !userData?.nickname) {
-    navigate(ROUTE_PATH.setup.setNickname);
   }
 
   return (

--- a/src/pages/Root/index.tsx
+++ b/src/pages/Root/index.tsx
@@ -19,8 +19,8 @@ export const Root = () => {
   const isProductionMode = import.meta.env.PROD;
 
   useLayoutEffect(() => {
-    if (isProductionMode && loginState) {
-      initializeAccessToken(accessToken, setAccessToken);
+    if (isProductionMode && loginState && !accessToken.length) {
+      initializeAccessToken(setAccessToken);
     }
   }, [isProductionMode, accessToken, setAccessToken, loginState]);
 

--- a/src/stores/atoms/loginStateAtom.ts
+++ b/src/stores/atoms/loginStateAtom.ts
@@ -1,13 +1,7 @@
-import { atom } from 'jotai';
+import { atomWithStorage, createJSONStorage } from 'jotai/utils';
 
-export const loginStateAtom = atom(false);
+const storage = createJSONStorage(() => {
+  return sessionStorage;
+});
 
-export const readWriteLoginState = atom(
-  (get) => {
-    return get(loginStateAtom);
-  },
-
-  (get, set, newLoginState: boolean) => {
-    return set(loginStateAtom, newLoginState);
-  },
-);
+export const loginStateAtom = atomWithStorage('loginState', false, storage);

--- a/src/utils/initializeAccessToken.ts
+++ b/src/utils/initializeAccessToken.ts
@@ -2,12 +2,7 @@ import { reissueAccessToken } from './reissueAccessToken';
 
 import type { Dispatch, SetStateAction } from 'react';
 
-export const initializeAccessToken = async (
-  accessToken: string,
-  setAccessToken: Dispatch<SetStateAction<string>>,
-) => {
-  if (!accessToken.length) {
-    const newAccessToken = await reissueAccessToken();
-    setAccessToken(newAccessToken);
-  }
+export const initializeAccessToken = async (setAccessToken: Dispatch<SetStateAction<string>>) => {
+  const newAccessToken = await reissueAccessToken();
+  setAccessToken(newAccessToken);
 };


### PR DESCRIPTION
## Issues
- Issue number #84 

## Tasks Done 
- [x] **initializeAccessToken** 함수가 실행되는 조건문에 **loginStateAtom** 추가
- [x] `LoginLoading` 페이지에서 **userData**를 가져오도록 로직 변경
- [x] **userDataAtom**이 아니라 **useUserData**의 응답 데이터에서 **nickname** 값을 확인하도록 수정
- [x]  **loginStateAtom**에서 **atomWithStorage**를 사용하도록 수정

## Description
- 지금까지 구현한 내용을 배포 환경에서 테스트했을 때 몇 가지 문제가 있었습니다.
  - 로그인도 하기 전에 **initializeAccessToken** 함수가 실행되는 문제
  - **userData**에 **nickname**이 있는데도 불구하고, **nickname** 설정 페이지로 이동하는 문제
  - 로그인 한 후 새로고침을 하면 로그인을 다시 해야 하는 문제

### 로그인도 하기 전에 initializeAccessToken 함수가 실행되는 문제
- 원인 : 실행되는 조건문에서 **accessToken** 길이만 확인하기 때문에 로그인 여부와 상관없이 **initializeAccessToken**함수가 실행되기 때문이었습니다.
- 해결책 : **initializeAccessToken** 함수가 실행되는 조건문에 **loginStateAtom** 추가하여 해결했습니다.
- 리팩터링 : **initializeAccessToken** 함수를 필요 이상으로 호출하지 않도록 **accessToken** 길이를 확인하는 조건문을 함수 밖으로 뺐습니다.
  - 초반에는 **useEffect** hook이 불필요하다고 생각하여 제거했습니다. 그러나 **initializeAccessToken** 함수 내부에서 POST 요청을 하기 때문에 React 외부 시스템인 Network와 동기화 작업이 필요하므로 **useEffect** hook을 다시 추가했습니다.

### **userData**에 **nickname**이 있는데도 불구하고, **nickname** 설정 페이지로 이동하는 문제
- 원인 : 로그인 후 `LoginLoading` 페이지로 이동했을 때는 아직 **useUserData**를 호출하기 전이므로 **userData**가 null이기 때문이었습니다.
- 해결책 : `LoginLoading` 페이지에서 **useUserData**를 호출하여 **userData**를 가져오도록 했습니다.
  - **userData**는 다음 렌더링 때 변경된 상태가 반영되므로, **useUserData**의 응답 데이터인 **data**의 **nickname**을 확인해서 null인 경우에만 `SetNickname` 페이지로 이동하도록 했습니다.
- 리팩터링 :  `MyPage` 페이지에서  **useUserData**를 호출하는 로직이 더 이상 필요하지 않으므로 제거했습니다. 

### 로그인 한 후 새로고침을 하면 로그인을 다시 해야 하는 문제
- 원인 : 새로고침을 하면 **loginStateAtom** 상태가 날아가기 때문이었습니다.
- 해결책 : **atomWithStorage**를 통해 Session Storage에 **loginStateAtom** 상태를 저장함으로써 해결했습니다.
  - **atomWithStorage**를 사용하면 타입이 unknown으로 추론되기 때문에 **type assertion**을 통해 타입을 단언해 주었습니다.
