### PR TITLE
[#86] Fix: move logic to navigate Roadmap page after setting userData

### DIFF
--- a/src/pages/LoginLoading/index.tsx
+++ b/src/pages/LoginLoading/index.tsx
@@ -23,13 +23,14 @@ export const LoginLoading = () => {
     if (accessTokenValue?.length) {
       setAccessToken(accessTokenValue);
       setLoginState(true);
-      navigate(ROUTE_PATH.roadmap.index);
     }
 
     if (isSuccess) {
       setUserData(data);
       if (!data.nickname) {
         navigate(ROUTE_PATH.setup.setNickname);
+      } else {
+        navigate(ROUTE_PATH.roadmap.index);
       }
     }
   }, [setAccessToken, setLoginState, navigate, data, isSuccess, setUserData]);


### PR DESCRIPTION
## Issues
- Issue number #86 

## Tasks Done 
- [x] **userData**가 상태에 저장된 후, data의 nickname 값이 존재할 경우에 `Roadmap` 페이지로 이동하도록 변경

## Description
#### Mypage 페이지에서 계속 로딩화면만 보여주는 문제
- 원인 : `LoginLoading` 페이지의 **accessToken** 길이 확인하는 조건문 안에서 `Roadmap` 페이지로 이동하는 코드 때문에 **userData**가 상태에 저장되기 전에 `Roadmap` 페이지로 이동되기 때문이었습니다.
- 해결책 : **userData**가 상태에 저장된 후, data의 nickname 값이 존재할 경우에 `Roadmap` 페이지로 이동하도록 코드 위치를 변경했습니다.
