### PR TITLE
Feat/#88 back button

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,8 +1,8 @@
 import { useAtomValue } from 'jotai';
 import { Link, useLocation } from 'react-router-dom';
 
+import { BackButton } from '@/components/buttons/BackButton';
 import { ROUTE_PATH } from '@/constants';
-import { usePreviousPage } from '@/hooks/usePreviousPage';
 import { loginStateAtom } from '@/stores/atoms/loginStateAtom';
 
 const BACK_BUTTON_VISIBILITY = {
@@ -14,17 +14,12 @@ export const Header = () => {
   const location = useLocation();
   const isMainPage = location.pathname === ROUTE_PATH.roadmap.index ? 'true' : 'false';
   const isLogin = useAtomValue(loginStateAtom) as boolean;
-  const handleBackButtonClick = usePreviousPage();
 
   return (
     <header className="flex items-center justify-between bg-black p-5">
-      <button
-        type="button"
-        className={`${BACK_BUTTON_VISIBILITY[isMainPage]}`}
-        onClick={handleBackButtonClick}
-      >
+      <BackButton classNames={`${BACK_BUTTON_VISIBILITY[isMainPage]}`}>
         <img src="/assets/images/back-button.svg" alt="backButton" />
-      </button>
+      </BackButton>
       <Link to={ROUTE_PATH.roadmap.index}>
         <img src="/assets/images/logo.svg" alt="Logo" />
       </Link>

--- a/src/components/buttons/BackButton/index.tsx
+++ b/src/components/buttons/BackButton/index.tsx
@@ -1,0 +1,18 @@
+import { usePreviousPage } from '@/hooks/usePreviousPage';
+
+import type { ReactNode } from 'react';
+
+type BackButtonProps = {
+  classNames: string;
+  children: ReactNode;
+};
+
+export const BackButton = ({ classNames, children }: BackButtonProps) => {
+  const handleBackButtonClick = usePreviousPage();
+
+  return (
+    <button type="button" className={`${classNames}`} onClick={handleBackButtonClick}>
+      {children}
+    </button>
+  );
+};

--- a/src/components/buttons/LoginButton/index.tsx
+++ b/src/components/buttons/LoginButton/index.tsx
@@ -1,3 +1,5 @@
+import { ROUTE_PATH } from '@/constants';
+
 type LoginButtonProps = {
   platform: 'google' | 'kakao' | 'naver';
   iconURL: string;
@@ -5,7 +7,9 @@ type LoginButtonProps = {
 };
 
 export const LoginButton = ({ platform, iconURL, style }: LoginButtonProps) => {
-  const AUTH_URL = `${import.meta.env.VITE_API_URL}/oauth2/authorization/${platform}`;
+  const AUTH_URL = import.meta.env.DEV
+    ? ROUTE_PATH.callback
+    : `${import.meta.env.VITE_API_URL}/oauth2/authorization/${platform}`;
 
   return (
     <a

--- a/src/pages/LoginLoading/index.tsx
+++ b/src/pages/LoginLoading/index.tsx
@@ -17,12 +17,12 @@ export const LoginLoading = () => {
   const setUserData = useSetAtom(userDataAtom);
   const { data, isSuccess } = useUserData(accessToken, setAccessToken);
   const navigate = useNavigate();
+  setLoginState(true);
 
   useEffect(() => {
     const accessTokenValue = getCookie(ACCESS_TOKEN_COOKIE_KEY);
     if (accessTokenValue?.length) {
       setAccessToken(accessTokenValue);
-      setLoginState(true);
     }
 
     if (isSuccess) {

--- a/src/pages/SelectWorkout/SelectableWorkoutCard.tsx
+++ b/src/pages/SelectWorkout/SelectableWorkoutCard.tsx
@@ -11,6 +11,8 @@ type SelectableWorkoutCardProps = Omit<WorkoutCardProps, 'additionalStyle' | 'ch
   isActive?: boolean;
 };
 
+const HANGING = 'Hanging';
+
 export const SelecteableWorkoutCard = ({
   id,
   title,
@@ -20,7 +22,7 @@ export const SelecteableWorkoutCard = ({
   height,
   isActive,
 }: SelectableWorkoutCardProps) => {
-  const [isCardSelected, setCardSelected] = useState(false);
+  const [isCardSelected, setCardSelected] = useState(isActive);
   const setWorkoutData = useSetAtom(workoutDataAtom);
 
   const handleCardClick = ({ target }: MouseEvent<HTMLElement>) => {
@@ -40,7 +42,7 @@ export const SelecteableWorkoutCard = ({
     setCardSelected(!isCardSelected);
   };
 
-  if (isActive) {
+  if (title === HANGING) {
     return (
       <WorkoutCard
         id={id}

--- a/src/pages/SelectWorkout/index.tsx
+++ b/src/pages/SelectWorkout/index.tsx
@@ -17,8 +17,6 @@ const TEXT_CONTENTS = {
   description: 'Hanging(매달리기) 동작은 기본적으로 선택되어 있어요.',
 } as const;
 
-const HANGING = 'Hanging';
-
 export const SelectWorkout = () => {
   const [workoutData, setWorkoutData] = useAtom(workoutDataAtom);
   const { nickname } = useAtomValue(userDataAtom) as UserData;
@@ -48,6 +46,10 @@ export const SelectWorkout = () => {
         </div>
         <div className="grid grid-cols-4 gap-x-3.5 gap-y-6 px-5 pb-5">
           {ROADMAP_DATA.map(({ id, title, imageSrc, color }) => {
+            const workout = workoutData.find(({ name }) => {
+              return name === title;
+            });
+
             return (
               <SelecteableWorkoutCard
                 key={id}
@@ -57,7 +59,7 @@ export const SelectWorkout = () => {
                 color={color}
                 width="4.75rem"
                 height="6.375rem"
-                isActive={title === HANGING}
+                isActive={workout?.selected}
               />
             );
           })}

--- a/src/pages/SelectWorkout/index.tsx
+++ b/src/pages/SelectWorkout/index.tsx
@@ -1,6 +1,7 @@
 import { useAtom, useAtomValue } from 'jotai';
 import { useNavigate } from 'react-router-dom';
 
+import { BackButton } from '@/components/buttons/BackButton';
 import { SaveButton } from '@/components/buttons/SaveButton';
 import { Headline } from '@/components/Headline';
 import { ROADMAP_DATA, ROUTE_PATH } from '@/constants';
@@ -62,14 +63,17 @@ export const SelectWorkout = () => {
           })}
         </div>
       </section>
-      <div className="flex justify-center pt-12">
+      <div className="flex justify-center gap-x-4 px-5 pt-12">
+        <BackButton classNames="h-[2.75rem] w-[9.375rem] bg-[#CFCFCF] rounded-[0.313rem] text-sm text-black">
+          이전으로 가기
+        </BackButton>
         <SaveButton
           isActive
           handleButtonClick={handleSaveButtonClick}
-          width="21.875rem"
+          width="9.375rem"
           height="2.75rem"
           text="다음으로 가기"
-          className="font-extrabold"
+          className="text-sm"
         />
       </div>
     </div>

--- a/src/pages/SetupResult/index.tsx
+++ b/src/pages/SetupResult/index.tsx
@@ -1,6 +1,7 @@
 import { useAtomValue } from 'jotai';
 import { useNavigate } from 'react-router-dom';
 
+import { BackButton } from '@/components/buttons/BackButton';
 import { SaveButton } from '@/components/buttons/SaveButton';
 import { Headline } from '@/components/Headline';
 import { ROADMAP_DATA, ROUTE_PATH } from '@/constants';
@@ -72,14 +73,17 @@ export const SetupResult = () => {
         <WorkoutResult workoutData={restWorkoutData} textContents={TEXT_CONTENTS.restWorkout} />
       </section>
       <p className="py-7 text-xs text-[#D9D9D9]">{TEXT_CONTENTS.edit.description}</p>
-      <div className="flex justify-center">
+      <div className="flex justify-center gap-x-4 px-5">
+        <BackButton classNames="h-[2.75rem] w-[9.375rem] bg-[#CFCFCF] rounded-[0.313rem] text-sm text-black">
+          이전으로 가기
+        </BackButton>
         <SaveButton
           isActive
           handleButtonClick={handleSaveButtonClick}
-          width="21.875rem"
+          width="9.375rem"
           height="2.75rem"
-          text="다음으로 가기"
-          className="font-extrabold"
+          text="Pullanner 시작하기"
+          className="text-sm"
         />
       </div>
     </div>


### PR DESCRIPTION
## Issues
- Issue number #88 

## Tasks Done 
- [x] `BackButton` 구현
- [x] `BackButton`을 사용하는 컴포넌트 및 페이지에 적용
  - [x] `Header`에 적용
  - [x] `SelectWorkout`에 적용
  - [x] `SetupResult`에 적용

## Description
### Feat
#### BackButton 구현 및 SelectWorkout, SetupResult 페이지에 BackButton 추가
- `Header` 컴포넌트의 뒤로 가기 화살표 버튼과 `SelectWorkout`, `SetupResult`의 "이전으로 가기" 버튼이 디자인만 다를 뿐 기능은 동일하므로 공통 컴포넌트 `BackButton`을 구현하여 재활용하도록 했습니다. 
  - `BackButton`에**classNames**와 **children**을 props로 선언하여 다양한 스타일 및 자식 요소를 넣을 수 있도록 했습니다.
  - `SelectWorkout`, `SetupResult` 페이지에서 `BackButton`을 사용하여 "이전으로 가기" 버튼을 추가했습니다.

### Refactor
#### Header 컴포넌트에 BackButton 적용 및 SetupResult 페이지의 "다음으로 가기" 문구 변경
 
- `Header` 컴포넌트의 뒤로 가기 화살표 버튼이 `BackButton`을 사용하도록 수정했습니다.
 - `SetupResult` 컴포넌트에서 "다음으로 가기" 버튼 문구를 "Pullanner 시작하기"로 변경했습니다.

#### 개발환경에서도 로그인 시 LoginLoading 페이지를 방문하도록 변경

- `MyPage`가 아니라 `LoginLoading` 페이지에서 **loginState**와 **userData** 상태가 설정되므로, 개발 환경에서 **loginState** 값을 임의로 true로 설정하는 것이 아니라 `LoginLoading` 페이지에 가야됩니다.
  - 그러므로  `LoginButton`의 **AUTH_PATH**에 삼항 연산자를 사용하여 개발 환경일 때 `LoginLoading` 페이지로 이동하도록 **ROUTE_PATH.callback**을 넣어주었습니다.
  - `LoginLoading` 페이지에서 **accessToken**의 여부와 관계 없이 **loginState**를 true로 설정하도록 **setLoginState** 함수 위치를 변경했습니다. 

#### SelectableWorkoutCard의 isActive 변수 용도 변경

- `SetupResult` 페이지에서 이전 페이지인 `SelectWorkout`로 이동했을 때, 선택했던 WorkoutCard 상태가 남아있어야 합니다.
  - 그러므로 **isActive** 변수의 용도를 바꾸어서, **workoutData**의 각 요소의 **selected** 상태에 따라 **isActive** 값이 변경되도록 수정했습니다.
  - `SelectableWorkoutCard` 컴포넌트에서 **isActive** 값에 따라 **isCardSelected** 초기값이 변경되도록 수정했습니다.
  - `SelectableWorkoutCard` 컴포넌트 내부에 **Hanging** 운동일 때 항상 활성화된 WorkoutCard가 되도록 하는 조건부 로직을 넣어주었습니다.

## Visuals

![backButton](https://github.com/Pullanner/pullanner-web/assets/70058081/ec0be934-d5f0-4baf-b96b-9123a251645a)

