### PR TITLE
Refactor/#90 my page

### DIFF
--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -1,5 +1,5 @@
 import { useSetAtom, useAtomValue } from 'jotai';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { DimmedButton } from '@/components/buttons/DimmedButton';
@@ -20,6 +20,7 @@ const MODAL_TEXT = '정말 로그아웃하시겠습니까?';
 
 export const MyPage = () => {
   const setAccessToken = useSetAtom(accessTokenAtom);
+  const loginState = useAtomValue(loginStateAtom) as boolean;
   const setLoginState = useSetAtom(loginStateAtom);
   const userData = useAtomValue(userDataAtom) as UserData;
   const setUserData = useSetAtom(userDataAtom);
@@ -43,6 +44,12 @@ export const MyPage = () => {
   const handleCancleButtonClick = () => {
     setShowModal(false);
   };
+
+  useEffect(() => {
+    if (!loginState) {
+      navigate(ROUTE_PATH.login);
+    }
+  }, [loginState, navigate]);
 
   // TODO: 추후에 로딩페이지로 교체하기
   if (!userData) {

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -1,7 +1,11 @@
 import { useSetAtom, useAtomValue } from 'jotai';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { DimmedButton } from '@/components/buttons/DimmedButton';
+import { Modal } from '@/components/Modal';
+import { ModalButton } from '@/components/Modal/ModalButton';
+import { SubText } from '@/components/Modal/ModalText';
 import { API_PATH, ROUTE_PATH } from '@/constants';
 import { axiosInstance } from '@/lib/axios/instance';
 import { accessTokenAtom } from '@/stores/atoms/accessTokenAtom';
@@ -12,19 +16,30 @@ import { ProgressSection } from './ProgressSection';
 import { TabSection } from './TabSection';
 import { UserSection } from './UserSection';
 
+const MODAL_TEXT = '정말 로그아웃하시겠습니까?';
+
 export const MyPage = () => {
   const setAccessToken = useSetAtom(accessTokenAtom);
   const setLoginState = useSetAtom(loginStateAtom);
   const userData = useAtomValue(userDataAtom) as UserData;
   const setUserData = useSetAtom(userDataAtom);
   const navigate = useNavigate();
+  const [showModal, setShowModal] = useState(false);
 
   const handleLogoutButtonClick = () => {
+    setShowModal(true);
+  };
+
+  const handleOkButtonClick = () => {
     axiosInstance.delete(API_PATH.token);
     setLoginState(false);
     setAccessToken('');
     setUserData(null);
     navigate(ROUTE_PATH.root);
+  };
+
+  const handleCancleButtonClick = () => {
+    setShowModal(false);
   };
 
   // TODO: 추후에 로딩페이지로 교체하기
@@ -42,6 +57,15 @@ export const MyPage = () => {
       <div className="flex justify-center">
         <DimmedButton name="로그아웃" handler={handleLogoutButtonClick} />
       </div>
+      {showModal && (
+        <Modal>
+          <SubText textStyle="p-5">{MODAL_TEXT}</SubText>
+          <div className="mb-5 flex w-full justify-around">
+            <ModalButton text="네" handler={handleOkButtonClick} />
+            <ModalButton text="아니오" handler={handleCancleButtonClick} isPrimary />
+          </div>
+        </Modal>
+      )}
     </div>
   );
 };

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -16,12 +16,14 @@ export const MyPage = () => {
   const setAccessToken = useSetAtom(accessTokenAtom);
   const setLoginState = useSetAtom(loginStateAtom);
   const userData = useAtomValue(userDataAtom) as UserData;
+  const setUserData = useSetAtom(userDataAtom);
   const navigate = useNavigate();
 
   const handleLogoutButtonClick = () => {
     axiosInstance.delete(API_PATH.token);
     setLoginState(false);
     setAccessToken('');
+    setUserData(null);
     navigate(ROUTE_PATH.root);
   };
 

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -31,7 +31,9 @@ export const MyPage = () => {
   };
 
   const handleOkButtonClick = () => {
-    axiosInstance.delete(API_PATH.token);
+    if (import.meta.env.PROD) {
+      axiosInstance.delete(API_PATH.token);
+    }
     setLoginState(false);
     setAccessToken('');
     setUserData(null);


### PR DESCRIPTION
## Issues
- Issue number #90 

## Tasks Done 
- [x] `MyPage`의 로그아웃 로직 수정
  - [x] 로그아웃 시 Session storage의 **userData**가 삭제하기
  - [x] 로그아웃 시 모달창을 띄워서 의사 한번 더 묻기
  - [x] 배포환경에서 로그아웃할 때만 DELETE 요청하기 
- [x] 로그인 상태가 아닐 때 `MyPage` 진입시 로그인 페이지로 이동하도록 수정

## Description

#### 로그아웃 시 로직 수정
- 로그아웃했을 때, Session Storage의 **userData**도 null로 초기화되도록 수정했습니다.
- 로그아웃했을 때, 모달창을 띄워서 사용자에게 로그아웃 의사를 한 번 더 묻도록 수정했습니다.
- 로그아웃했을 때 **accessToken**을 삭제하는 DELETE 요청은 **refreshToken**가 필요하므로, **refreshToken**이 있는 배포 환경에서만 실행되도록 조건문을 추가했습니다.

#### 로그인 상태가 아닐 경우 로그인 페이지로 리다이렉트 로직 추가
- 마이페이지에 진입 시 로그인 상태가 아닐 경우 로그인 페이지로 이동하는 로직을 **useEffect** hook 안에 추가했습니다.

## Visuals

#### 로그아웃 모달창 구현

<img width="191" alt="스크린샷 2023-08-15 155523" src="https://github.com/Pullanner/pullanner-web/assets/70058081/e59986a4-2781-4ece-af15-1e02dfe0633c">

#### 로그인 상태가 아닐 때 마이페이지 진입시 로그인 페이지로 리다이렉트 구현

![redirect](https://github.com/Pullanner/pullanner-web/assets/70058081/7ab4e46c-153a-4e3e-99fb-3ea98437b7e9)


