### PR TITLE
Feat/#93 delete account timer

### DIFF
--- a/src/pages/DeleteAccount/AuthenticationCodeInput.tsx
+++ b/src/pages/DeleteAccount/AuthenticationCodeInput.tsx
@@ -9,6 +9,7 @@ import { MainText, SubText, ModalText } from '@/components/Modal/ModalText';
 import { ROUTE_PATH } from '@/constants';
 import { accessTokenAtom } from '@/stores/atoms/accessTokenAtom';
 import { loginStateAtom } from '@/stores/atoms/loginStateAtom';
+import { timerStateAtom } from '@/stores/atoms/timerStateAtom';
 import { userDataAtom } from '@/stores/atoms/userDataAtom';
 
 import {
@@ -23,13 +24,12 @@ import { Timer } from './Timer';
 import type { ChangeEvent, Dispatch, SetStateAction, ForwardedRef } from 'react';
 
 type AuthenticationCodeInputProps = {
-  isTimerActive: boolean;
   setSendCodeButtonActive: Dispatch<SetStateAction<boolean>>;
 };
 
 export const AuthenticationCodeInput = forwardRef<HTMLInputElement, AuthenticationCodeInputProps>(
   (
-    { isTimerActive, setSendCodeButtonActive }: AuthenticationCodeInputProps,
+    { setSendCodeButtonActive }: AuthenticationCodeInputProps,
     ref: ForwardedRef<HTMLInputElement>,
   ) => {
     const [authenticationCode, setAuthenticationCode] = useState('');
@@ -37,6 +37,7 @@ export const AuthenticationCodeInput = forwardRef<HTMLInputElement, Authenticati
     const [isDeleteRequestFailed, setShowInvalidAuthenticationCodeDescription] = useState(false);
     const [showModal, setShowModal] = useState(false);
     const [accessToken, setAccessToken] = useAtom(accessTokenAtom);
+    const [timerState, setTimerState] = useAtom(timerStateAtom);
     const setLoginState = useSetAtom(loginStateAtom);
     const setUserData = useSetAtom(userDataAtom);
     const navigate = useNavigate();
@@ -79,6 +80,7 @@ export const AuthenticationCodeInput = forwardRef<HTMLInputElement, Authenticati
       setShowModal(false);
       setLoginState(false);
       setUserData(null);
+      setTimerState({ isVisible: false, reset: false });
       navigate(ROUTE_PATH.roadmap.index);
     };
 
@@ -97,7 +99,7 @@ export const AuthenticationCodeInput = forwardRef<HTMLInputElement, Authenticati
             aria-label="authenticationCode"
             aria-describedby="valdationResult"
           />
-          {isTimerActive && <Timer limitTime={LIMIT_TIME} />}
+          {timerState.isVisible && <Timer limitTime={LIMIT_TIME} />}
           <button
             type="button"
             className={`h-[1.875rem] w-[4.5rem] rounded-[0.313rem] text-base ${VALIDATE_CODE_BUTTON_STYLE[deleteAccountButtonState]}`}

--- a/src/pages/DeleteAccount/index.tsx
+++ b/src/pages/DeleteAccount/index.tsx
@@ -6,19 +6,24 @@ import { sendAuthenticationCode } from '@/apis/user/sendAuthenticationCode';
 import { SaveButton } from '@/components/buttons/SaveButton';
 import { SuccessIcon } from '@/components/icons/SuccessIcon';
 import { accessTokenAtom } from '@/stores/atoms/accessTokenAtom';
+import { timerStateAtom } from '@/stores/atoms/timerStateAtom';
 
 import { AuthenticationCodeInput } from './AuthenticationCodeInput';
 import { DeleteAccountDescription } from './DeleteAccountDescription';
 
 export const DeleteAccount = () => {
-  const [isTimerActive, setTimerActive] = useState(false);
+  const [timerState, setTimerState] = useAtom(timerStateAtom);
   const [isSendCodeButtonActive, setSendCodeButtonActive] = useState(true);
   const [accessToken, setAccessToken] = useAtom(accessTokenAtom);
   const [messageApi, contextHolder] = message.useMessage();
   const inputRef = useRef<HTMLInputElement>(null);
 
   const handleSendCodeButtonClick = async () => {
-    setTimerActive(true);
+    if (timerState.isVisible) {
+      setTimerState({ ...timerState, reset: true });
+    } else {
+      setTimerState({ ...timerState, isVisible: true });
+    }
     if (inputRef.current) {
       inputRef.current.focus();
     }
@@ -48,11 +53,7 @@ export const DeleteAccount = () => {
         text="인증 코드 전송하기"
         className="text-sm"
       />
-      <AuthenticationCodeInput
-        isTimerActive={isTimerActive}
-        setSendCodeButtonActive={setSendCodeButtonActive}
-        ref={inputRef}
-      />
+      <AuthenticationCodeInput setSendCodeButtonActive={setSendCodeButtonActive} ref={inputRef} />
       {contextHolder}
     </div>
   );

--- a/src/stores/atoms/timerStateAtom.ts
+++ b/src/stores/atoms/timerStateAtom.ts
@@ -1,0 +1,17 @@
+import { atom } from 'jotai';
+
+const initialTimerState = {
+  isVisible: false,
+  reset: false,
+};
+
+export const timerStateAtom = atom(initialTimerState);
+
+export const readWriteAtom = atom(
+  (get) => {
+    return get(timerStateAtom);
+  },
+  (get, set, newTimerStateAtom: typeof initialTimerState) => {
+    set(timerStateAtom, newTimerStateAtom);
+  },
+);


### PR DESCRIPTION
## Issues
- Issue number #93

## Tasks Done 
- [x] 타이머 리셋 기능 구현
  - [x] 타이머 관련 전역 상태로 **timerStateAtom**를 선언
  - [x]  **timerStateAtom**의 **reset** 속성이 true일 때, **timeSpan** state를 초기화
- [x] `DeleteAccount`와 `AuthenticationCodeInput` 컴포넌트에 `timerStateAtom` 적용
  - [x] **isTimerActive** 변수를 **timerStateAtom**의 **isVisble** 속성으로 변경
  - [x] **"인증코드 전송하기"** 버튼 클릭 시 조건문 추가
    - [x]  **isVisble**이 true면, **reset**을 true로 설정하여 `Timer`를 리셋함
    - [x]  **isVisble**이 false면, **isVisible**을 true로 설정하여 `Timer`를 보여줌
  - [x] 회원탈퇴 완료 모달의 **"확인"** 버튼 클릭 시 **timerStateAtom** 값 초기화 

## Description
### timerStateAtom 선언
- 이유 : `DeleteAccount`, `AuthenticationCodeInput`, `Timer` 순으로 depth 2 이상으로 상태를 공유하고 있기 때문에, 전역 상태로 선언하여 **props drilling**을 없앴습니다.
- **timerStateAtom**은 **isVisble**과 **reset** 속성을 가진 객체입니다.
  - **isVisble**이 true일 경우, `Timer` 컴포넌트를 렌더링합니다.
  - **reset**이 true일 경우, `Timer` 컴포넌트의 **setInterval**을 초기화합니다.

### useTimer 훅 수정
- **setInterval**을 초기화하기 위해, **setInterval**의 id를 저장할 **intervalIdRef**를 선언했습니다.
  - **intervalIdRef**의 타입을 쉽게 설정하기 위해서 반환 타입이 `NodeJs.Timer`인 **setInterval** 대신 `number` 타입인 **window.setInterval**을 사용했습니다.
-  **timerStateAtom**의 **reset** 속성이 true인 경우, **intervalIdRef.current**를 사용하여 setInterval을 취소하고 **timeSpan** 상태를 제한 시간으로 초기화했습니다.
- `useTimer` 훅을 구독하고 있는 컴포넌트가 언마운트될 때, **setInterval**이 취소하는 클린업 함수가 작성된 `useEffect` 훅을 추가했습니다.

### DeleteAccount, AuthenticationCodeInput 컴포넌트에 timerStateAtom 적용
- `DeleteAccount` 컴포넌트의 **isTimerActive** 상태를 **timerStateAtom**의 **isVisible** 속성으로 교체했습니다.
- `DeleteAccount` 컴포넌트의 **"인증코드 전송하기"** 버튼을 클릭했을 때, **timerStateAtom**의 **isVisible** 속성에 따른 조건문을 추가했습니다.
  - **timerStateAtom**의 **isVisible** 속성이 true라면, 현재 실행 중인 `Timer`가 존재하므로 **timerStateAtom**의 **reset** 속성을 true로 설정하여 `Timer`가 리셋되도록 구현했습니다.
  - **timerStateAtom**의 **isVisible** 속성이 false라면, 현재 실행 중인 `Timer`가 없으므로 **timerStateAtom**의 **isVisible** 속성을 true로 설정하여 `Timer`를 렌더링하도록 구현했습니다.
- `AuthenticationCodeInput` 컴포넌트의 회원 탈퇴 완료 모달의 **"확인"** 커튼을 클릭했을 때, **timerStateAtom**의 **isVisible**, **reset** 속성이 false로 초기화되도록 구현했습니다.

## Visuals
![resetTimer](https://github.com/Pullanner/pullanner-web/assets/70058081/00e710c6-bfa3-4bbc-8d53-72aed155b27b)

