### PR TITLE
Design/#96 modal

### DIFF
--- a/src/components/Modal/ModalButton.tsx
+++ b/src/components/Modal/ModalButton.tsx
@@ -18,11 +18,11 @@ export const ModalButton = ({
   return (
     <button
       type="button"
-      className={`${primaryButtonStyle} ${buttonStyle} flex min-h-[2.5rem] min-w-[3.75rem] items-center justify-center gap-y-0.5 rounded-md bg-[#373737] p-2`}
+      className={`${primaryButtonStyle} ${buttonStyle} flex h-[3.125rem] w-full items-center justify-center gap-y-0.5 bg-[#373737] p-2`}
       onClick={handler}
     >
       {imageUrl && <img src={imageUrl} alt="emoticon" className="mr-1.5 h-5 w-5" />}
-      <span className="inline-block text-xs">{text}</span>
+      <span className="text-sm">{text}</span>
     </button>
   );
 };

--- a/src/components/Modal/ModalText.tsx
+++ b/src/components/Modal/ModalText.tsx
@@ -6,7 +6,7 @@ type TextProps = {
 };
 
 export const ModalText = ({ children, textStyle = '' }: TextProps) => {
-  return <div className={`${textStyle}`}>{children}</div>;
+  return <div className={`${textStyle} text-center`}>{children}</div>;
 };
 
 export const MainText = ({ children, textStyle }: TextProps) => {
@@ -14,5 +14,5 @@ export const MainText = ({ children, textStyle }: TextProps) => {
 };
 
 export const SubText = ({ children, textStyle }: TextProps) => {
-  return <p className={`${textStyle} text-sm leading-6`}>{children}</p>;
+  return <p className={`${textStyle} px-5 text-sm leading-6`}>{children}</p>;
 };

--- a/src/pages/DeleteAccount/AuthenticationCodeInput.tsx
+++ b/src/pages/DeleteAccount/AuthenticationCodeInput.tsx
@@ -103,22 +103,17 @@ export const AuthenticationCodeInput = forwardRef<HTMLInputElement>(
         )}
         {showModal && (
           <Modal>
-            <ModalText textStyle="flex flex-col items-center justify-center px-5 pt-5">
-              <MainText textStyle="pb-2.5">{TEXT_CONTENTS.modal.main}</MainText>
-              <div className="border-t-2 border-[#686868] pt-2.5 text-center">
+            <ModalText>
+              <MainText textStyle="border-b-2 border-[#686868] py-5">
+                {TEXT_CONTENTS.modal.main}
+              </MainText>
+              <SubText textStyle="pt-6 pb-7">
                 {TEXT_CONTENTS.modal.sub.map((text) => {
-                  return <SubText key={text}>{text}</SubText>;
+                  return <p key={text}>{text}</p>;
                 })}
-              </div>
+              </SubText>
             </ModalText>
-            <div className="mb-5 flex w-full justify-center pt-2.5">
-              <ModalButton
-                text="확인"
-                buttonStyle="w-[5.625rem] h-7"
-                handler={handleOkButtonClick}
-                isPrimary
-              />
-            </div>
+            <ModalButton text="확인" handler={handleOkButtonClick} isPrimary />
           </Modal>
         )}
       </div>

--- a/src/pages/DeleteAccount/AuthenticationCodeInput.tsx
+++ b/src/pages/DeleteAccount/AuthenticationCodeInput.tsx
@@ -1,16 +1,9 @@
-import { useAtom, useSetAtom, useAtomValue } from 'jotai';
+import { useAtom, useAtomValue } from 'jotai';
 import { useState, forwardRef } from 'react';
-import { useNavigate } from 'react-router-dom';
 
 import { deleteAccountWithAuthenticationCode } from '@/apis/user/deleteAccountWithAuthenticationCode';
-import { Modal } from '@/components/Modal';
-import { ModalButton } from '@/components/Modal/ModalButton';
-import { MainText, SubText, ModalText } from '@/components/Modal/ModalText';
-import { ROUTE_PATH } from '@/constants';
 import { accessTokenAtom } from '@/stores/atoms/accessTokenAtom';
 import { isTimerActiveAtom } from '@/stores/atoms/isTimerActiveAtom';
-import { loginStateAtom } from '@/stores/atoms/loginStateAtom';
-import { userDataAtom } from '@/stores/atoms/userDataAtom';
 
 import {
   MAX_INPUT_LENGTH,
@@ -19,6 +12,7 @@ import {
   VALIDATE_CODE_BUTTON_STYLE,
   LIMIT_TIME,
 } from './constants';
+import { DeleteAccountSuccessModal } from './DeleteAccountSuccessModal';
 import { Timer } from './Timer';
 
 import type { ChangeEvent, ForwardedRef } from 'react';
@@ -30,10 +24,7 @@ export const AuthenticationCodeInput = forwardRef<HTMLInputElement>(
     const [isDeleteRequestFailed, setShowInvalidAuthenticationCodeDescription] = useState(false);
     const [showModal, setShowModal] = useState(false);
     const [accessToken, setAccessToken] = useAtom(accessTokenAtom);
-    const setLoginState = useSetAtom(loginStateAtom);
-    const setUserData = useSetAtom(userDataAtom);
     const isTimerActive = useAtomValue(isTimerActiveAtom);
-    const navigate = useNavigate();
 
     const deleteAccountButtonState = isDeleteAccountButtonActive
       ? BUTTON_STATE.active
@@ -65,13 +56,6 @@ export const AuthenticationCodeInput = forwardRef<HTMLInputElement>(
       setDeleteAccountButtonActive(inputNumberValue.length === MAX_INPUT_LENGTH);
     };
 
-    const handleOkButtonClick = () => {
-      setShowModal(false);
-      setLoginState(false);
-      setUserData(null);
-      navigate(ROUTE_PATH.roadmap.index);
-    };
-
     return (
       <div className="pt-6">
         <div className="flex h-11 items-center justify-between rounded-[0.313rem] bg-[#161616] px-2.5">
@@ -101,17 +85,7 @@ export const AuthenticationCodeInput = forwardRef<HTMLInputElement>(
             {TEXT_CONTENTS.invalidAuthenticationCodeDescription}
           </p>
         )}
-        {showModal && (
-          <Modal>
-            <ModalText>
-              <MainText textStyle="border-b-2 border-[#686868] py-5">
-                {TEXT_CONTENTS.modal.title}
-              </MainText>
-              <SubText textStyle="pt-6 pb-7">{TEXT_CONTENTS.modal.greeting}</SubText>
-            </ModalText>
-            <ModalButton text="확인" handler={handleOkButtonClick} isPrimary />
-          </Modal>
-        )}
+        {showModal && <DeleteAccountSuccessModal setShowModal={setShowModal} />}
       </div>
     );
   },

--- a/src/pages/DeleteAccount/AuthenticationCodeInput.tsx
+++ b/src/pages/DeleteAccount/AuthenticationCodeInput.tsx
@@ -105,13 +105,9 @@ export const AuthenticationCodeInput = forwardRef<HTMLInputElement>(
           <Modal>
             <ModalText>
               <MainText textStyle="border-b-2 border-[#686868] py-5">
-                {TEXT_CONTENTS.modal.main}
+                {TEXT_CONTENTS.modal.title}
               </MainText>
-              <SubText textStyle="pt-6 pb-7">
-                {TEXT_CONTENTS.modal.sub.map((text) => {
-                  return <p key={text}>{text}</p>;
-                })}
-              </SubText>
+              <SubText textStyle="pt-6 pb-7">{TEXT_CONTENTS.modal.greeting}</SubText>
             </ModalText>
             <ModalButton text="확인" handler={handleOkButtonClick} isPrimary />
           </Modal>

--- a/src/pages/DeleteAccount/DeleteAccountSuccessModal.tsx
+++ b/src/pages/DeleteAccount/DeleteAccountSuccessModal.tsx
@@ -1,0 +1,42 @@
+import { useSetAtom } from 'jotai';
+import { useNavigate } from 'react-router-dom';
+
+import { Modal } from '@/components/Modal';
+import { ModalButton } from '@/components/Modal/ModalButton';
+import { MainText, SubText, ModalText } from '@/components/Modal/ModalText';
+import { ROUTE_PATH } from '@/constants';
+import { loginStateAtom } from '@/stores/atoms/loginStateAtom';
+import { userDataAtom } from '@/stores/atoms/userDataAtom';
+
+import { TEXT_CONTENTS } from './constants';
+
+import type { Dispatch, SetStateAction } from 'react';
+
+type DeleteAccountSuccessModalProps = {
+  setShowModal: Dispatch<SetStateAction<boolean>>;
+};
+
+export const DeleteAccountSuccessModal = ({ setShowModal }: DeleteAccountSuccessModalProps) => {
+  const setLoginState = useSetAtom(loginStateAtom);
+  const setUserData = useSetAtom(userDataAtom);
+  const navigate = useNavigate();
+
+  const handleOkButtonClick = () => {
+    setShowModal(false);
+    setLoginState(false);
+    setUserData(null);
+    navigate(ROUTE_PATH.roadmap.index);
+  };
+
+  return (
+    <Modal>
+      <ModalText>
+        <MainText textStyle="border-b-2 border-[#686868] py-5">
+          {TEXT_CONTENTS.modal.title}
+        </MainText>
+        <SubText textStyle="pt-6 pb-7">{TEXT_CONTENTS.modal.greeting}</SubText>
+      </ModalText>
+      <ModalButton text="확인" handler={handleOkButtonClick} isPrimary />
+    </Modal>
+  );
+};

--- a/src/pages/DeleteAccount/constants.ts
+++ b/src/pages/DeleteAccount/constants.ts
@@ -3,11 +3,8 @@ export const MAX_INPUT_LENGTH = 6;
 export const TEXT_CONTENTS = {
   invalidAuthenticationCodeDescription: '유효하지 않은 인증번호입니다.',
   modal: {
-    main: '회원 탈퇴',
-    sub: [
-      'pullanner 회원 탈퇴가 완료되었습니다.',
-      '그동안 Pullanner 서비스를 이용해주셔서 감사합니다.',
-    ],
+    title: '회원 탈퇴가 완료되었습니다',
+    greeting: '그동안 Pullanner를 이용해주셔서 감사합니다.',
   },
 } as const;
 

--- a/src/pages/EditMyPage/DeleteAccountModal.tsx
+++ b/src/pages/EditMyPage/DeleteAccountModal.tsx
@@ -1,0 +1,45 @@
+import { useNavigate } from 'react-router-dom';
+
+import { Modal } from '@/components/Modal';
+import { ModalButton } from '@/components/Modal/ModalButton';
+import { MainText, SubText, ModalText } from '@/components/Modal/ModalText';
+import { ROUTE_PATH } from '@/constants';
+
+import { MODAL_TEXT } from './constants';
+
+type DeleteAccountModalProps = {
+  handleCancleButtonClick: () => void;
+};
+
+export const DeleteAccountModal = ({ handleCancleButtonClick }: DeleteAccountModalProps) => {
+  const navigate = useNavigate();
+
+  const handleOkButtonClick = () => {
+    navigate(ROUTE_PATH.deleteAccount);
+  };
+
+  return (
+    <Modal>
+      <ModalText>
+        <MainText textStyle="py-5 border-b-2 border-[#686868]">{MODAL_TEXT.title}</MainText>
+        <SubText textStyle="pt-5 pb-7">
+          <p>{MODAL_TEXT.description}</p>
+          <p className="font-extrabold">{MODAL_TEXT.warning}</p>
+        </SubText>
+      </ModalText>
+      <div className="flex w-full">
+        <ModalButton
+          text="네"
+          handler={handleOkButtonClick}
+          imageUrl="/assets/images/emotion/2.svg"
+        />
+        <ModalButton
+          text="아니오"
+          handler={handleCancleButtonClick}
+          imageUrl="/assets/images/emotion/5.svg"
+          isPrimary
+        />
+      </div>
+    </Modal>
+  );
+};

--- a/src/pages/EditMyPage/constants.ts
+++ b/src/pages/EditMyPage/constants.ts
@@ -1,0 +1,10 @@
+export const INPUT_LENGTH = {
+  min: 2,
+  max: 8,
+} as const;
+
+export const MODAL_TEXT = {
+  title: '회원 탈퇴',
+  description: 'Pullanner의 모든 데이터가 삭제됩니다.',
+  warning: '삭제된 데이터는 복구할 수 없습니다.',
+} as const;

--- a/src/pages/EditMyPage/index.tsx
+++ b/src/pages/EditMyPage/index.tsx
@@ -14,14 +14,7 @@ import { useMutateNickname } from '@/lib/react-query/useUserData';
 import { accessTokenAtom } from '@/stores/atoms/accessTokenAtom';
 import { userDataAtom, UserData } from '@/stores/atoms/userDataAtom';
 
-const INPUT_LENGTH = {
-  min: 2,
-  max: 8,
-} as const;
-
-const MODAL_MAIN_TEXT = '정말 탈퇴하시겠습니까?';
-const MODAL_SUB_TEXT1 = '회원 탈퇴시 Pullanner의 모든 데이터가 삭제됩니다.';
-const MODAL_SUB_TEXT2 = '삭제된 데이터는 복구할 수 없습니다.';
+import { INPUT_LENGTH, MODAL_TEXT } from './constants';
 
 export const EditMyPage = () => {
   const userData = useAtomValue(userDataAtom) as UserData;
@@ -79,10 +72,10 @@ export const EditMyPage = () => {
       {showModal && (
         <Modal>
           <ModalText>
-            <MainText textStyle="py-5 border-b-2 border-[#686868]">{MODAL_MAIN_TEXT}</MainText>
+            <MainText textStyle="py-5 border-b-2 border-[#686868]">{MODAL_TEXT.title}</MainText>
             <SubText textStyle="pt-5 pb-7">
-              <p>{MODAL_SUB_TEXT1}</p>
-              <p className="font-extrabold">{MODAL_SUB_TEXT2}</p>
+              <p>{MODAL_TEXT.description}</p>
+              <p className="font-extrabold">{MODAL_TEXT.warning}</p>
             </SubText>
           </ModalText>
           <div className="flex w-full">

--- a/src/pages/EditMyPage/index.tsx
+++ b/src/pages/EditMyPage/index.tsx
@@ -20,8 +20,8 @@ const INPUT_LENGTH = {
 } as const;
 
 const MODAL_MAIN_TEXT = '정말 탈퇴하시겠습니까?';
-const MODAL_SUB_TEXT =
-  '회원 탈퇴시 Pullanner의 모든 데이터가 삭제됩니다. 삭제된 데이터는 복구할 수 없습니다.';
+const MODAL_SUB_TEXT1 = '회원 탈퇴시 Pullanner의 모든 데이터가 삭제됩니다.';
+const MODAL_SUB_TEXT2 = '삭제된 데이터는 복구할 수 없습니다.';
 
 export const EditMyPage = () => {
   const userData = useAtomValue(userDataAtom) as UserData;
@@ -78,11 +78,14 @@ export const EditMyPage = () => {
       <DimmedButton name="회원탈퇴" handler={handleWithdrwalButtonClick} />
       {showModal && (
         <Modal>
-          <ModalText textStyle="p-5">
-            <MainText textStyle="mb-4 text-red-400">{MODAL_MAIN_TEXT}</MainText>
-            <SubText>{MODAL_SUB_TEXT}</SubText>
+          <ModalText>
+            <MainText textStyle="py-5 border-b-2 border-[#686868]">{MODAL_MAIN_TEXT}</MainText>
+            <SubText textStyle="pt-5 pb-7">
+              <p>{MODAL_SUB_TEXT1}</p>
+              <p className="font-extrabold">{MODAL_SUB_TEXT2}</p>
+            </SubText>
           </ModalText>
-          <div className="mb-2 flex w-full justify-around p-3">
+          <div className="flex w-full">
             <ModalButton
               text="네"
               handler={handleOkButtonClick}

--- a/src/pages/EditMyPage/index.tsx
+++ b/src/pages/EditMyPage/index.tsx
@@ -6,15 +6,13 @@ import { validateNickname } from '@/apis/user';
 import { DimmedButton } from '@/components/buttons/DimmedButton';
 import { SaveButton } from '@/components/buttons/SaveButton';
 import { DuplicationCheckInput } from '@/components/DuplicationCheckInput';
-import { Modal } from '@/components/Modal';
-import { ModalButton } from '@/components/Modal/ModalButton';
-import { MainText, SubText, ModalText } from '@/components/Modal/ModalText';
 import { ROUTE_PATH } from '@/constants';
 import { useMutateNickname } from '@/lib/react-query/useUserData';
 import { accessTokenAtom } from '@/stores/atoms/accessTokenAtom';
 import { userDataAtom, UserData } from '@/stores/atoms/userDataAtom';
 
-import { INPUT_LENGTH, MODAL_TEXT } from './constants';
+import { INPUT_LENGTH } from './constants';
+import { DeleteAccountModal } from './DeleteAccountModal';
 
 export const EditMyPage = () => {
   const userData = useAtomValue(userDataAtom) as UserData;
@@ -37,10 +35,6 @@ export const EditMyPage = () => {
 
   const handleWithdrwalButtonClick = () => {
     setShowModal(true);
-  };
-
-  const handleOkButtonClick = () => {
-    navigate(ROUTE_PATH.deleteAccount);
   };
 
   const handleCancleButtonClick = () => {
@@ -69,30 +63,7 @@ export const EditMyPage = () => {
       </div>
 
       <DimmedButton name="회원탈퇴" handler={handleWithdrwalButtonClick} />
-      {showModal && (
-        <Modal>
-          <ModalText>
-            <MainText textStyle="py-5 border-b-2 border-[#686868]">{MODAL_TEXT.title}</MainText>
-            <SubText textStyle="pt-5 pb-7">
-              <p>{MODAL_TEXT.description}</p>
-              <p className="font-extrabold">{MODAL_TEXT.warning}</p>
-            </SubText>
-          </ModalText>
-          <div className="flex w-full">
-            <ModalButton
-              text="네"
-              handler={handleOkButtonClick}
-              imageUrl="/assets/images/emotion/2.svg"
-            />
-            <ModalButton
-              text="아니오"
-              handler={handleCancleButtonClick}
-              imageUrl="/assets/images/emotion/5.svg"
-              isPrimary
-            />
-          </div>
-        </Modal>
-      )}
+      {showModal && <DeleteAccountModal handleCancleButtonClick={handleCancleButtonClick} />}
     </div>
   );
 };

--- a/src/pages/MyPage/LogoutModal.tsx
+++ b/src/pages/MyPage/LogoutModal.tsx
@@ -1,0 +1,46 @@
+import { useSetAtom } from 'jotai';
+import { useNavigate } from 'react-router-dom';
+
+import { Modal } from '@/components/Modal';
+import { ModalButton } from '@/components/Modal/ModalButton';
+import { MainText, ModalText } from '@/components/Modal/ModalText';
+import { API_PATH, ROUTE_PATH } from '@/constants';
+import { axiosInstance } from '@/lib/axios/instance';
+import { accessTokenAtom } from '@/stores/atoms/accessTokenAtom';
+import { loginStateAtom } from '@/stores/atoms/loginStateAtom';
+import { userDataAtom } from '@/stores/atoms/userDataAtom';
+
+import { MODAL_TEXT } from './constants';
+
+type LogoutModalProps = {
+  handleCancleButtonClick: () => void;
+};
+
+export const LogoutModal = ({ handleCancleButtonClick }: LogoutModalProps) => {
+  const setAccessToken = useSetAtom(accessTokenAtom);
+  const setLoginState = useSetAtom(loginStateAtom);
+  const setUserData = useSetAtom(userDataAtom);
+  const navigate = useNavigate();
+
+  const handleOkButtonClick = () => {
+    if (import.meta.env.PROD) {
+      axiosInstance.delete(API_PATH.token);
+    }
+    setLoginState(false);
+    setAccessToken('');
+    setUserData(null);
+    navigate(ROUTE_PATH.root);
+  };
+
+  return (
+    <Modal>
+      <ModalText textStyle="py-7">
+        <MainText>{MODAL_TEXT}</MainText>
+      </ModalText>
+      <div className="flex w-full">
+        <ModalButton text="네" handler={handleOkButtonClick} />
+        <ModalButton text="아니오" handler={handleCancleButtonClick} isPrimary />
+      </div>
+    </Modal>
+  );
+};

--- a/src/pages/MyPage/constants.ts
+++ b/src/pages/MyPage/constants.ts
@@ -13,3 +13,5 @@ export const MY_PAGE_TAB_STYLE = {
   active: 'w-36 h-8 border-b border-primary text-center text-main font-bold',
   inActive: 'w-36 h-8 text-gray-500 text-center text-main font-normal',
 } as const;
+
+export const MODAL_TEXT = '정말 로그아웃하시겠습니까?';

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -5,7 +5,7 @@ import { useNavigate } from 'react-router-dom';
 import { DimmedButton } from '@/components/buttons/DimmedButton';
 import { Modal } from '@/components/Modal';
 import { ModalButton } from '@/components/Modal/ModalButton';
-import { SubText } from '@/components/Modal/ModalText';
+import { MainText, ModalText } from '@/components/Modal/ModalText';
 import { API_PATH, ROUTE_PATH } from '@/constants';
 import { axiosInstance } from '@/lib/axios/instance';
 import { accessTokenAtom } from '@/stores/atoms/accessTokenAtom';
@@ -68,8 +68,10 @@ export const MyPage = () => {
       </div>
       {showModal && (
         <Modal>
-          <SubText textStyle="p-5">{MODAL_TEXT}</SubText>
-          <div className="mb-5 flex w-full justify-around">
+          <ModalText textStyle="py-7">
+            <MainText>{MODAL_TEXT}</MainText>
+          </ModalText>
+          <div className="flex w-full">
             <ModalButton text="네" handler={handleOkButtonClick} />
             <ModalButton text="아니오" handler={handleCancleButtonClick} isPrimary />
           </div>

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -12,11 +12,10 @@ import { accessTokenAtom } from '@/stores/atoms/accessTokenAtom';
 import { loginStateAtom } from '@/stores/atoms/loginStateAtom';
 import { userDataAtom, UserData } from '@/stores/atoms/userDataAtom';
 
+import { MODAL_TEXT } from './constants';
 import { ProgressSection } from './ProgressSection';
 import { TabSection } from './TabSection';
 import { UserSection } from './UserSection';
-
-const MODAL_TEXT = '정말 로그아웃하시겠습니까?';
 
 export const MyPage = () => {
   const setAccessToken = useSetAtom(accessTokenAtom);

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -1,43 +1,25 @@
-import { useSetAtom, useAtomValue } from 'jotai';
+import { useAtomValue } from 'jotai';
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { DimmedButton } from '@/components/buttons/DimmedButton';
-import { Modal } from '@/components/Modal';
-import { ModalButton } from '@/components/Modal/ModalButton';
-import { MainText, ModalText } from '@/components/Modal/ModalText';
-import { API_PATH, ROUTE_PATH } from '@/constants';
-import { axiosInstance } from '@/lib/axios/instance';
-import { accessTokenAtom } from '@/stores/atoms/accessTokenAtom';
+import { ROUTE_PATH } from '@/constants';
 import { loginStateAtom } from '@/stores/atoms/loginStateAtom';
 import { userDataAtom, UserData } from '@/stores/atoms/userDataAtom';
 
-import { MODAL_TEXT } from './constants';
+import { LogoutModal } from './LogoutModal';
 import { ProgressSection } from './ProgressSection';
 import { TabSection } from './TabSection';
 import { UserSection } from './UserSection';
 
 export const MyPage = () => {
-  const setAccessToken = useSetAtom(accessTokenAtom);
   const loginState = useAtomValue(loginStateAtom) as boolean;
-  const setLoginState = useSetAtom(loginStateAtom);
   const userData = useAtomValue(userDataAtom) as UserData;
-  const setUserData = useSetAtom(userDataAtom);
   const navigate = useNavigate();
   const [showModal, setShowModal] = useState(false);
 
   const handleLogoutButtonClick = () => {
     setShowModal(true);
-  };
-
-  const handleOkButtonClick = () => {
-    if (import.meta.env.PROD) {
-      axiosInstance.delete(API_PATH.token);
-    }
-    setLoginState(false);
-    setAccessToken('');
-    setUserData(null);
-    navigate(ROUTE_PATH.root);
   };
 
   const handleCancleButtonClick = () => {
@@ -65,17 +47,7 @@ export const MyPage = () => {
       <div className="flex justify-center">
         <DimmedButton name="로그아웃" handler={handleLogoutButtonClick} />
       </div>
-      {showModal && (
-        <Modal>
-          <ModalText textStyle="py-7">
-            <MainText>{MODAL_TEXT}</MainText>
-          </ModalText>
-          <div className="flex w-full">
-            <ModalButton text="네" handler={handleOkButtonClick} />
-            <ModalButton text="아니오" handler={handleCancleButtonClick} isPrimary />
-          </div>
-        </Modal>
-      )}
+      {showModal && <LogoutModal handleCancleButtonClick={handleCancleButtonClick} />}
     </div>
   );
 };


### PR DESCRIPTION
## Issues
- Issue number #96 

## Tasks Done 
- [x] 변경된 모달 디자인을 반영하여 모달 관련 컴포넌트들 수정하기
- [x] 모달을 사용하고 있는 컴포넌트에 변경 사항 적용하기
  - [x] 로그아웃 모달 디자인 수정
  - [x] 회원탈퇴 모달 디자인 수정
  - [x] 회원탈퇴 완료 모달 디자인 수정
- [x] 페이지 내 모달을 컴포넌트 파일로 분리하기

## Description
### ModalButton, ModalText, SubText의 CSS 변경
- 각 컴포넌트에 변경된 모달 디자인을 반영했습니다.
  - `ModalButton` 컴포넌트
    - width (1개일 경우 350px, 2개일 경우 175px)로 변경 => **min-h-[2.5rem]** 삭제, **w-full** 설정
    - height 50px로 변경 => **min-w-[3.75rem]** 삭제, **h-[3.125rem]** 설정
    - 글자 크기 14px에서 16px로 변경 => **text-xs**에서 **text-sm**로 변경
    - 불필요한 **inline-block** 삭제
  - `ModalText` 컴포넌트
    - 글자 가운데 정렬 => **text-center** 설정
  - `SubText` 컴포넌트
    - 글자 양옆 여백 20px 설정 => **px-5** 설정

<br>

### 로그아웃 모달 디자인 변경
- 글자가 가운데 정렬이 되도록 `SubText`를 `ModalText`로 감쌌습니다.
- 글자 크기가 14px에서 16px로 변경되었으므로, `SubText`를 `MainText`로 변경했습니다.
- 버튼들을 감싸는 div 태그에서 불필요한 **mb-5**, **justify-arount**를 삭제했습니다.

<br>

### 회원 탈퇴 모달 디자인 변경 및 리팩터링
- 디자인 변경
  - `MainText`에 위아래 여백으로 **py-5**를 설정했습니다.
  - 구분선을 보여주기 위해 `MainText`에 **border-b-2**와 border-[#686868]를 설정했습니다.
  -  **MODAL_SUB_TEXT**를 둘로 나누고, "삭제된 데이터는 복구할 수 없습니다" 글자에 **font-extrabold**를 설정했습니다.
     - 와이어프레임에서는 bold 스타일로 지정되어 있지만, **font-bold**로 했을 경우 육안으로 뚜렷한 차이가 보이지 않아서 **font-extrabold**로 설정했습니다.
  - 버튼들을 감싸는 div 태그에서 불필요한 **mb-2**, **justify-around**, **p-3**을 삭제했습니다.
- 리팩터링
  - **MODAL_MAIN_TEXT**, **MODAL_SUB_TEXT1**, **MODAL_SUB_TEXT2**을 객체 형태 **MODAL_TEXT**로 묶어주었습니다.
  - **MODAL_TEXT**와 **INPUT_LENGTH**를 `constants` 파일로 옮겼습니다. 

<br>

### 회원 탈퇴 완료 모달 디자인 변경 및 리팩터링
- 디자인 변경
  - `ModalText`에서 불필요한 flex 관련 CSS(**flex**, **flex-col**, **items-center**, **justify-center**)와 padding 관련 CSS(**px-5**, **pt-5**)를 삭제했습니다.
  - `MainText`에서 위아래 여백으로 **py-5**를 설정했습니다.
  - 구분선을 보여주기 위해 `MainText`에 **border-b-2**와 border-[#686868]를 설정했습니다.
  - 버튼을 감싸는 div 태그의 스타일이 더 이상 필요하지 않으므로 div 태그를 삭제했습니다.
  - `ModalButton`에 **width**와 **height**가 설정되어 있으므로 그에 해당하는 **buttonStyle** props 값을 삭제했습니다.
- 리팩터링
  - **TEXT_CONTENTS**의 **modal**의 **main** 값을 "회원 탈퇴가 완료되었습니다"로 변경했습니다.
  - **TEXT_CONTENTS**의 **modal**의 **sub** 값을 "그동안 Pullanner를 이용해주셔서 감사합니다"로 변경했습니다.
  - **main**, **sub** 대신 의미가 드러나는 **title**, **greeting**으로 이름을 변경했습니다.
  - **MODAL_TEXT**를 `constants` 파일로 옮겼습니다.

<br>

### 로그아웃, 회원 탈퇴, 회원 탈퇴 완료 모달을 파일로 분리
- 모달 관련 UI 및 로직을 파일로 분리하는 것이 유지 보수 관점에서 좋다고 판단하여 파일로 분리했습니다.
- `MyPage`의 로그아웃 모달을 `LogoutModal` 파일로 분리했습니다.
  - **handleCancleButtonClick** 함수는 `MyPage`에서 선언한 **setShowModal**을 참조하고 있기 때문에, 핸들러 자체를 props로 넘겨받도록 구현했습니다.
- `EditMyPage`의 회원 탈퇴 모달을 `DeletAccountModal` 파일로 분리했습니다.
  - **handleCancleButtonClick** 함수는 `EditMyPage`에서 선언한 **setShowModal**을 참조하고 있기 때문에, 핸들러 자체를 props로 넘겨받도록 구현했습니다.
- `AuthenticationCodeInput`의 회원 탈퇴 완료 모달을 `DeleteAccountSuccessModal` 파일로 분리했습니다.
  - **handleCancleButtonClick** 함수는 `EditMyPage`에서 선언한 **setShowModal**을 참조하고 있지만, **setLoginState**, **setUserData**는 모달에서만 사용합니다.
   - 따라서 **handleCancleButtonClick** 함수는 `DeleteAccountSuccessModal` 파일 내부에서 선언하고, **setShowModal**을 props로 넘겨받도록 구현했습니다.

<br>

## Visuals
#### 로그아웃, 회원 탈퇴, 회원 탈퇴 완료 모달
<img width="173" alt="스크린샷 2023-08-25 031025" src="https://github.com/Pullanner/pullanner-web/assets/70058081/6309d00d-6cf4-40aa-a9b8-d30368f913c9">
<img width="174" alt="스크린샷 2023-08-25 031044" src="https://github.com/Pullanner/pullanner-web/assets/70058081/6ad69b17-e69f-4140-81aa-41332ec942f5">
<img width="173" alt="스크린샷 2023-08-25 031105" src="https://github.com/Pullanner/pullanner-web/assets/70058081/958e3cb5-5eee-4d90-aa9d-b5801f72bb56">
