### PR TITLE
Refactor/#116 summary

### DIFF
--- a/src/constants/summary.ts
+++ b/src/constants/summary.ts
@@ -23,3 +23,10 @@ export const MONTH_NAME_IN_KOREAN = {
   NOV: '11월',
   DEC: '12월',
 };
+
+export const TIME_NAME_IN_KOREAN = {
+  night: '새벽',
+  morning: '아침',
+  afternoon: '낮',
+  evening: '밤',
+};

--- a/src/constants/summary.ts
+++ b/src/constants/summary.ts
@@ -7,7 +7,7 @@ export const COLOR_BY_WORKOUT = {
   'Chest to Bar': '#8BB3FF',
   'Archer Pull-Up': '#CD7BFF',
   'Muscle Up': '#FF8CF4',
-};
+} as const;
 
 export const MONTH_NAME_IN_KOREAN = {
   JAN: '1월',
@@ -22,11 +22,11 @@ export const MONTH_NAME_IN_KOREAN = {
   OCT: '10월',
   NOV: '11월',
   DEC: '12월',
-};
+} as const;
 
 export const TIME_NAME_IN_KOREAN = {
   night: '새벽',
   morning: '아침',
   afternoon: '낮',
   evening: '밤',
-};
+} as const;

--- a/src/constants/summary.ts
+++ b/src/constants/summary.ts
@@ -9,17 +9,17 @@ export const COLOR_BY_WORKOUT = {
   'Muscle Up': '#FF8CF4',
 };
 
-export const FULL_MONTH_NAME_BY_ABBREVIATION = {
-  JAN: 'January',
-  FEB: 'February',
-  MAR: 'March',
-  APR: 'April',
-  MAY: 'May',
-  JUN: 'June',
-  JUL: 'July',
-  AUG: 'August',
-  SEP: 'September',
-  OCT: 'October',
-  NOV: 'November',
-  DEC: 'December',
+export const MONTH_NAME_IN_KOREAN = {
+  JAN: '1월',
+  FEB: '2월',
+  MAR: '3월',
+  APR: '4월',
+  MAY: '5월',
+  JUN: '6월',
+  JUL: '7월',
+  AUG: '8월',
+  SEP: '9월',
+  OCT: '10월',
+  NOV: '11월',
+  DEC: '12월',
 };

--- a/src/constants/summary.ts
+++ b/src/constants/summary.ts
@@ -10,16 +10,16 @@ export const COLOR_BY_WORKOUT = {
 };
 
 export const FULL_MONTH_NAME_BY_ABBREVIATION = {
-  Jan: 'January',
-  Feb: 'February',
-  Mar: 'March',
-  Apr: 'April',
-  May: 'May',
-  Jun: 'June',
-  Jul: 'July',
-  Aug: 'August',
-  Sep: 'September',
-  Oct: 'October',
-  Nov: 'November',
-  Dec: 'December',
+  JAN: 'January',
+  FEB: 'February',
+  MAR: 'March',
+  APR: 'April',
+  MAY: 'May',
+  JUN: 'June',
+  JUL: 'July',
+  AUG: 'August',
+  SEP: 'September',
+  OCT: 'October',
+  NOV: 'November',
+  DEC: 'December',
 };

--- a/src/mocks/summaries/completedPlanCount/data.ts
+++ b/src/mocks/summaries/completedPlanCount/data.ts
@@ -1,5 +1,18 @@
+export type CompletedPlanCount = {
+  completedPlanCountByTime: {
+    time: 'morning' | 'afternoon' | 'evening' | 'night';
+    thisMonth: number;
+    prevMonth: number;
+  }[];
+};
+
 export const COMPLETED_PLAN_COUNT_DATA = {
   completedPlanCountByTime: [
+    {
+      time: 'night',
+      thisMonth: 40,
+      prevMonth: 45,
+    },
     {
       time: 'morning',
       thisMonth: 20,
@@ -17,5 +30,3 @@ export const COMPLETED_PLAN_COUNT_DATA = {
     },
   ],
 };
-
-export type CompletedPlanCount = typeof COMPLETED_PLAN_COUNT_DATA;

--- a/src/mocks/summaries/monthWorkoutCount/data.ts
+++ b/src/mocks/summaries/monthWorkoutCount/data.ts
@@ -1,4 +1,4 @@
-import { FULL_MONTH_NAME_BY_ABBREVIATION } from '@/constants';
+import { MONTH_NAME_IN_KOREAN } from '@/constants';
 
 type WorkoutNames =
   | 'Hanging'
@@ -13,7 +13,7 @@ type WorkoutNames =
 export type MonthWorkoutCount = {
   data: {
     [K in WorkoutNames]: {
-      month: keyof typeof FULL_MONTH_NAME_BY_ABBREVIATION;
+      month: keyof typeof MONTH_NAME_IN_KOREAN;
       totalCount: number;
     }[];
   };

--- a/src/mocks/summaries/monthWorkoutCount/data.ts
+++ b/src/mocks/summaries/monthWorkoutCount/data.ts
@@ -11,219 +11,223 @@ type WorkoutNames =
   | 'Muscle Up';
 
 export type MonthWorkoutCount = {
-  [K in WorkoutNames]: {
-    month: keyof typeof FULL_MONTH_NAME_BY_ABBREVIATION;
-    totalCount: number;
-  }[];
+  data: {
+    [K in WorkoutNames]: {
+      month: keyof typeof FULL_MONTH_NAME_BY_ABBREVIATION;
+      totalCount: number;
+    }[];
+  };
 };
 
-export const MONTH_WORKOUT_COUNT_DATA: MonthWorkoutCount = {
-  Hanging: [
-    {
-      month: 'May',
-      totalCount: 200,
-    },
-    {
-      month: 'Jun',
-      totalCount: 300,
-    },
-    {
-      month: 'Jul',
-      totalCount: 400,
-    },
-    {
-      month: 'Aug',
-      totalCount: 300,
-    },
-    {
-      month: 'Sep',
-      totalCount: 200,
-    },
-    {
-      month: 'Oct',
-      totalCount: 100,
-    },
-  ],
-  'Jumping Pull-Up': [
-    {
-      month: 'May',
-      totalCount: 300,
-    },
-    {
-      month: 'Jun',
-      totalCount: 400,
-    },
-    {
-      month: 'Jul',
-      totalCount: 300,
-    },
-    {
-      month: 'Aug',
-      totalCount: 200,
-    },
-    {
-      month: 'Sep',
-      totalCount: 100,
-    },
-    {
-      month: 'Oct',
-      totalCount: 100,
-    },
-  ],
-  'Band Pull-Up': [
-    {
-      month: 'May',
-      totalCount: 500,
-    },
-    {
-      month: 'Jun',
-      totalCount: 400,
-    },
-    {
-      month: 'Jul',
-      totalCount: 300,
-    },
-    {
-      month: 'Aug',
-      totalCount: 200,
-    },
-    {
-      month: 'Sep',
-      totalCount: 100,
-    },
-    {
-      month: 'Oct',
-      totalCount: 200,
-    },
-  ],
-  'Chin-Up': [
-    {
-      month: 'May',
-      totalCount: 100,
-    },
-    {
-      month: 'Jun',
-      totalCount: 200,
-    },
-    {
-      month: 'Jul',
-      totalCount: 300,
-    },
-    {
-      month: 'Aug',
-      totalCount: 400,
-    },
-    {
-      month: 'Sep',
-      totalCount: 300,
-    },
-    {
-      month: 'Oct',
-      totalCount: 200,
-    },
-  ],
-  'Pull-Up': [
-    {
-      month: 'May',
-      totalCount: 100,
-    },
-    {
-      month: 'Jun',
-      totalCount: 100,
-    },
-    {
-      month: 'Jul',
-      totalCount: 200,
-    },
-    {
-      month: 'Aug',
-      totalCount: 300,
-    },
-    {
-      month: 'Sep',
-      totalCount: 400,
-    },
-    {
-      month: 'Oct',
-      totalCount: 300,
-    },
-  ],
-  'Chest to Bar': [
-    {
-      month: 'May',
-      totalCount: 200,
-    },
-    {
-      month: 'Jun',
-      totalCount: 100,
-    },
-    {
-      month: 'Jul',
-      totalCount: 200,
-    },
-    {
-      month: 'Aug',
-      totalCount: 300,
-    },
-    {
-      month: 'Sep',
-      totalCount: 400,
-    },
-    {
-      month: 'Oct',
-      totalCount: 500,
-    },
-  ],
-  'Archer Pull-Up': [
-    {
-      month: 'May',
-      totalCount: 500,
-    },
-    {
-      month: 'Jun',
-      totalCount: 300,
-    },
-    {
-      month: 'Jul',
-      totalCount: 400,
-    },
-    {
-      month: 'Aug',
-      totalCount: 300,
-    },
-    {
-      month: 'Sep',
-      totalCount: 200,
-    },
-    {
-      month: 'Oct',
-      totalCount: 100,
-    },
-  ],
-  'Muscle Up': [
-    {
-      month: 'May',
-      totalCount: 300,
-    },
-    {
-      month: 'Jun',
-      totalCount: 450,
-    },
-    {
-      month: 'Jul',
-      totalCount: 400,
-    },
-    {
-      month: 'Aug',
-      totalCount: 300,
-    },
-    {
-      month: 'Sep',
-      totalCount: 200,
-    },
-    {
-      month: 'Oct',
-      totalCount: 200,
-    },
-  ],
+export const MONTH_WORKOUT_COUNT_DATA = {
+  data: {
+    Hanging: [
+      {
+        month: 'May',
+        totalCount: 200,
+      },
+      {
+        month: 'Jun',
+        totalCount: 300,
+      },
+      {
+        month: 'Jul',
+        totalCount: 400,
+      },
+      {
+        month: 'Aug',
+        totalCount: 300,
+      },
+      {
+        month: 'Sep',
+        totalCount: 200,
+      },
+      {
+        month: 'Oct',
+        totalCount: 100,
+      },
+    ],
+    'Jumping Pull-Up': [
+      {
+        month: 'May',
+        totalCount: 300,
+      },
+      {
+        month: 'Jun',
+        totalCount: 400,
+      },
+      {
+        month: 'Jul',
+        totalCount: 300,
+      },
+      {
+        month: 'Aug',
+        totalCount: 200,
+      },
+      {
+        month: 'Sep',
+        totalCount: 100,
+      },
+      {
+        month: 'Oct',
+        totalCount: 100,
+      },
+    ],
+    'Band Pull-Up': [
+      {
+        month: 'May',
+        totalCount: 500,
+      },
+      {
+        month: 'Jun',
+        totalCount: 400,
+      },
+      {
+        month: 'Jul',
+        totalCount: 300,
+      },
+      {
+        month: 'Aug',
+        totalCount: 200,
+      },
+      {
+        month: 'Sep',
+        totalCount: 100,
+      },
+      {
+        month: 'Oct',
+        totalCount: 200,
+      },
+    ],
+    'Chin-Up': [
+      {
+        month: 'May',
+        totalCount: 100,
+      },
+      {
+        month: 'Jun',
+        totalCount: 200,
+      },
+      {
+        month: 'Jul',
+        totalCount: 300,
+      },
+      {
+        month: 'Aug',
+        totalCount: 400,
+      },
+      {
+        month: 'Sep',
+        totalCount: 300,
+      },
+      {
+        month: 'Oct',
+        totalCount: 200,
+      },
+    ],
+    'Pull-Up': [
+      {
+        month: 'May',
+        totalCount: 100,
+      },
+      {
+        month: 'Jun',
+        totalCount: 100,
+      },
+      {
+        month: 'Jul',
+        totalCount: 200,
+      },
+      {
+        month: 'Aug',
+        totalCount: 300,
+      },
+      {
+        month: 'Sep',
+        totalCount: 400,
+      },
+      {
+        month: 'Oct',
+        totalCount: 300,
+      },
+    ],
+    'Chest to Bar': [
+      {
+        month: 'May',
+        totalCount: 200,
+      },
+      {
+        month: 'Jun',
+        totalCount: 100,
+      },
+      {
+        month: 'Jul',
+        totalCount: 200,
+      },
+      {
+        month: 'Aug',
+        totalCount: 300,
+      },
+      {
+        month: 'Sep',
+        totalCount: 400,
+      },
+      {
+        month: 'Oct',
+        totalCount: 500,
+      },
+    ],
+    'Archer Pull-Up': [
+      {
+        month: 'May',
+        totalCount: 500,
+      },
+      {
+        month: 'Jun',
+        totalCount: 300,
+      },
+      {
+        month: 'Jul',
+        totalCount: 400,
+      },
+      {
+        month: 'Aug',
+        totalCount: 300,
+      },
+      {
+        month: 'Sep',
+        totalCount: 200,
+      },
+      {
+        month: 'Oct',
+        totalCount: 100,
+      },
+    ],
+    'Muscle Up': [
+      {
+        month: 'May',
+        totalCount: 300,
+      },
+      {
+        month: 'Jun',
+        totalCount: 450,
+      },
+      {
+        month: 'Jul',
+        totalCount: 400,
+      },
+      {
+        month: 'Aug',
+        totalCount: 300,
+      },
+      {
+        month: 'Sep',
+        totalCount: 200,
+      },
+      {
+        month: 'Oct',
+        totalCount: 200,
+      },
+    ],
+  },
 };

--- a/src/mocks/summaries/monthWorkoutCount/data.ts
+++ b/src/mocks/summaries/monthWorkoutCount/data.ts
@@ -23,209 +23,209 @@ export const MONTH_WORKOUT_COUNT_DATA = {
   data: {
     Hanging: [
       {
-        month: 'May',
+        month: 'MAY',
         totalCount: 200,
       },
       {
-        month: 'Jun',
+        month: 'JUN',
         totalCount: 300,
       },
       {
-        month: 'Jul',
+        month: 'JUL',
         totalCount: 400,
       },
       {
-        month: 'Aug',
+        month: 'AUG',
         totalCount: 300,
       },
       {
-        month: 'Sep',
+        month: 'SEP',
         totalCount: 200,
       },
       {
-        month: 'Oct',
+        month: 'OCT',
         totalCount: 100,
       },
     ],
     'Jumping Pull-Up': [
       {
-        month: 'May',
+        month: 'MAY',
         totalCount: 300,
       },
       {
-        month: 'Jun',
+        month: 'JUN',
         totalCount: 400,
       },
       {
-        month: 'Jul',
+        month: 'JUL',
         totalCount: 300,
       },
       {
-        month: 'Aug',
+        month: 'AUG',
         totalCount: 200,
       },
       {
-        month: 'Sep',
+        month: 'SEP',
         totalCount: 100,
       },
       {
-        month: 'Oct',
+        month: 'OCT',
         totalCount: 100,
       },
     ],
     'Band Pull-Up': [
       {
-        month: 'May',
+        month: 'MAY',
         totalCount: 500,
       },
       {
-        month: 'Jun',
+        month: 'JUN',
         totalCount: 400,
       },
       {
-        month: 'Jul',
+        month: 'JUL',
         totalCount: 300,
       },
       {
-        month: 'Aug',
+        month: 'AUG',
         totalCount: 200,
       },
       {
-        month: 'Sep',
+        month: 'SEP',
         totalCount: 100,
       },
       {
-        month: 'Oct',
+        month: 'OCT',
         totalCount: 200,
       },
     ],
     'Chin-Up': [
       {
-        month: 'May',
+        month: 'MAY',
         totalCount: 100,
       },
       {
-        month: 'Jun',
+        month: 'JUN',
         totalCount: 200,
       },
       {
-        month: 'Jul',
+        month: 'JUL',
         totalCount: 300,
       },
       {
-        month: 'Aug',
+        month: 'AUG',
         totalCount: 400,
       },
       {
-        month: 'Sep',
+        month: 'SEP',
         totalCount: 300,
       },
       {
-        month: 'Oct',
+        month: 'OCT',
         totalCount: 200,
       },
     ],
     'Pull-Up': [
       {
-        month: 'May',
+        month: 'MAY',
         totalCount: 100,
       },
       {
-        month: 'Jun',
+        month: 'JUN',
         totalCount: 100,
       },
       {
-        month: 'Jul',
+        month: 'JUL',
         totalCount: 200,
       },
       {
-        month: 'Aug',
+        month: 'AUG',
         totalCount: 300,
       },
       {
-        month: 'Sep',
+        month: 'SEP',
         totalCount: 400,
       },
       {
-        month: 'Oct',
+        month: 'OCT',
         totalCount: 300,
       },
     ],
     'Chest to Bar': [
       {
-        month: 'May',
+        month: 'MAY',
         totalCount: 200,
       },
       {
-        month: 'Jun',
+        month: 'JUN',
         totalCount: 100,
       },
       {
-        month: 'Jul',
+        month: 'JUL',
         totalCount: 200,
       },
       {
-        month: 'Aug',
+        month: 'AUG',
         totalCount: 300,
       },
       {
-        month: 'Sep',
+        month: 'SEP',
         totalCount: 400,
       },
       {
-        month: 'Oct',
+        month: 'OCT',
         totalCount: 500,
       },
     ],
     'Archer Pull-Up': [
       {
-        month: 'May',
+        month: 'MAY',
         totalCount: 500,
       },
       {
-        month: 'Jun',
+        month: 'JUN',
         totalCount: 300,
       },
       {
-        month: 'Jul',
+        month: 'JUL',
         totalCount: 400,
       },
       {
-        month: 'Aug',
+        month: 'AUG',
         totalCount: 300,
       },
       {
-        month: 'Sep',
+        month: 'SEP',
         totalCount: 200,
       },
       {
-        month: 'Oct',
+        month: 'OCT',
         totalCount: 100,
       },
     ],
     'Muscle Up': [
       {
-        month: 'May',
+        month: 'MAY',
         totalCount: 300,
       },
       {
-        month: 'Jun',
+        month: 'JUN',
         totalCount: 450,
       },
       {
-        month: 'Jul',
+        month: 'JUL',
         totalCount: 400,
       },
       {
-        month: 'Aug',
+        month: 'AUG',
         totalCount: 300,
       },
       {
-        month: 'Sep',
+        month: 'SEP',
         totalCount: 200,
       },
       {
-        month: 'Oct',
+        month: 'OCT',
         totalCount: 200,
       },
     ],

--- a/src/pages/Summary/CompletedPlanCountByTimeChart/index.tsx
+++ b/src/pages/Summary/CompletedPlanCountByTimeChart/index.tsx
@@ -17,7 +17,7 @@ export const CompletedPlanCountByTimeChart = () => {
 
   const { completedPlanCountByTime: completedPlanCountData } = data;
 
-  const MOST_WORKOUT_TIME = completedPlanCountData.reduce((prevWorkout, workout) => {
+  const timeWithTheMostWorkout = completedPlanCountData.reduce((prevWorkout, workout) => {
     return prevWorkout.thisMonth >= workout.thisMonth ? prevWorkout : workout;
   }).time;
 
@@ -34,7 +34,7 @@ export const CompletedPlanCountByTimeChart = () => {
   return (
     <section className="flex w-full flex-col items-center bg-gray-6 py-4">
       <p className="pb-4 text-center text-xs">
-        주로 <span className="text-primary">{TIME_NAME_IN_KOREAN[MOST_WORKOUT_TIME]}</span>에
+        주로 <span className="text-primary">{TIME_NAME_IN_KOREAN[timeWithTheMostWorkout]}</span>에
         운동하시네요!
       </p>
       <BarChart width={330} height={300} data={completedPlanCountByTimeData}>

--- a/src/pages/Summary/CompletedPlanCountByTimeChart/index.tsx
+++ b/src/pages/Summary/CompletedPlanCountByTimeChart/index.tsx
@@ -25,8 +25,8 @@ export const CompletedPlanCountByTimeChart = () => {
     ({ time, thisMonth, prevMonth }) => {
       return {
         시간대: TIME_NAME_IN_KOREAN[time],
-        '이번달 플랜수': thisMonth,
-        '저번달 플랜수': prevMonth,
+        '이번달 플랜 수': thisMonth,
+        '저번달 플랜 수': prevMonth,
       };
     },
   );
@@ -48,8 +48,8 @@ export const CompletedPlanCountByTimeChart = () => {
           labelStyle={{ color: 'black' }}
         />
         <Legend />
-        <Bar dataKey="저번달 플랜수" fill="#8D8D8D" />
-        <Bar dataKey="이번달 플랜수" fill="#60EBD1" />
+        <Bar dataKey="저번달 플랜 수" fill="#8D8D8D" />
+        <Bar dataKey="이번달 플랜 수" fill="#60EBD1" />
       </BarChart>
     </section>
   );

--- a/src/pages/Summary/CompletedPlanCountByTimeChart/index.tsx
+++ b/src/pages/Summary/CompletedPlanCountByTimeChart/index.tsx
@@ -37,7 +37,7 @@ export const CompletedPlanCountByTimeChart = () => {
         주로 <span className="text-primary">{TIME_NAME_IN_KOREAN[MOST_WORKOUT_TIME]}</span>에
         운동하시네요!
       </p>
-      <BarChart width={350} height={300} data={completedPlanCountByTimeData}>
+      <BarChart width={330} height={300} data={completedPlanCountByTimeData}>
         <CartesianGrid strokeDasharray="3 3" />
         <XAxis dataKey="시간대" />
         <YAxis />

--- a/src/pages/Summary/CompletedPlanCountByTimeChart/index.tsx
+++ b/src/pages/Summary/CompletedPlanCountByTimeChart/index.tsx
@@ -1,6 +1,7 @@
 import { useAtom, useSetAtom } from 'jotai';
 import { Bar, BarChart, Legend, CartesianGrid, Tooltip, XAxis, YAxis } from 'recharts';
 
+import { TIME_NAME_IN_KOREAN } from '@/constants';
 import { useGetCompletedPlanCount } from '@/lib/react-query/useCompletedPlanCount';
 import { accessTokenAtom } from '@/stores/atoms/accessTokenAtom';
 import { modalTypeAtom } from '@/stores/atoms/modalTypeAtom';
@@ -14,30 +15,41 @@ export const CompletedPlanCountByTimeChart = () => {
     return null;
   }
 
-  const { completedPlanCountByTime: completedPlanCountByTimeData } = data;
+  const { completedPlanCountByTime: completedPlanCountData } = data;
 
-  const MOST_WORKOUT_TIME = completedPlanCountByTimeData.reduce((prevWorkout, workout) => {
+  const MOST_WORKOUT_TIME = completedPlanCountData.reduce((prevWorkout, workout) => {
     return prevWorkout.thisMonth >= workout.thisMonth ? prevWorkout : workout;
   }).time;
+
+  const completedPlanCountByTimeData = completedPlanCountData.map(
+    ({ time, thisMonth, prevMonth }) => {
+      return {
+        시간대: TIME_NAME_IN_KOREAN[time],
+        '이번달 플랜수': thisMonth,
+        '저번달 플랜수': prevMonth,
+      };
+    },
+  );
 
   return (
     <section className="flex w-full flex-col items-center bg-gray-6 py-4">
       <p className="pb-4 text-center text-xs">
-        주로 <span className="text-primary">{MOST_WORKOUT_TIME}</span>에 운동하시네요!
+        주로 <span className="text-primary">{TIME_NAME_IN_KOREAN[MOST_WORKOUT_TIME]}</span>에
+        운동하시네요!
       </p>
       <BarChart width={350} height={300} data={completedPlanCountByTimeData}>
         <CartesianGrid strokeDasharray="3 3" />
-        <XAxis dataKey="time" />
+        <XAxis dataKey="시간대" />
         <YAxis />
         <Tooltip
           labelFormatter={(value) => {
-            return `time : ${value}`;
+            return `시간대 : ${value}`;
           }}
           labelStyle={{ color: 'black' }}
         />
         <Legend />
-        <Bar dataKey="prevMonth" fill="#8D8D8D" />
-        <Bar dataKey="thisMonth" fill="#60EBD1" />
+        <Bar dataKey="저번달 플랜수" fill="#8D8D8D" />
+        <Bar dataKey="이번달 플랜수" fill="#60EBD1" />
       </BarChart>
     </section>
   );

--- a/src/pages/Summary/MonthlyTotalCountByEachWorkoutChart/index.tsx
+++ b/src/pages/Summary/MonthlyTotalCountByEachWorkoutChart/index.tsx
@@ -31,7 +31,7 @@ export const MonthlyTotalCountByEachWorkoutChart = () => {
 
   const { data: allMonthWorkoutCountData } = data;
 
-  const MOST_WORKOUT_MONTH = allMonthWorkoutCountData[workoutName].reduce(
+  const monthWithTheMostWorkout = allMonthWorkoutCountData[workoutName].reduce(
     (prevWorkout, workout) => {
       return prevWorkout.totalCount >= workout.totalCount ? prevWorkout : workout;
     },
@@ -56,7 +56,7 @@ export const MonthlyTotalCountByEachWorkoutChart = () => {
       <MonthDropdown handleDropdownItemClick={handleDropdownItemClick} workoutName={workoutName} />
       <div className="flex w-full flex-col items-center bg-gray-6 py-4">
         <p className="pb-4 text-center text-xs">
-          <span className="text-primary">{MONTH_NAME_IN_KOREAN[MOST_WORKOUT_MONTH]}</span>에{' '}
+          <span className="text-primary">{MONTH_NAME_IN_KOREAN[monthWithTheMostWorkout]}</span>에{' '}
           {workoutName}을 가장 많이 하셨어요!
         </p>
         <LineChart width={350} height={350} data={monthWorkoutCountData}>

--- a/src/pages/Summary/MonthlyTotalCountByEachWorkoutChart/index.tsx
+++ b/src/pages/Summary/MonthlyTotalCountByEachWorkoutChart/index.tsx
@@ -2,7 +2,7 @@ import { useAtom, useSetAtom } from 'jotai';
 import { useState, type MouseEvent } from 'react';
 import { LineChart, Legend, Line, CartesianGrid, Tooltip, XAxis, YAxis } from 'recharts';
 
-import { COLOR_BY_WORKOUT, FULL_MONTH_NAME_BY_ABBREVIATION } from '@/constants';
+import { COLOR_BY_WORKOUT, MONTH_NAME_IN_KOREAN } from '@/constants';
 import { useGetMonthWorkoutCount } from '@/lib/react-query/useMonthWorkoutCount';
 import { accessTokenAtom } from '@/stores/atoms/accessTokenAtom';
 import { modalTypeAtom } from '@/stores/atoms/modalTypeAtom';
@@ -29,34 +29,43 @@ export const MonthlyTotalCountByEachWorkoutChart = () => {
     return null;
   }
 
-  const { data: monthWorkoutCountData } = data;
+  const { data: allMonthWorkoutCountData } = data;
 
-  const MOST_WORKOUT_MONTH = monthWorkoutCountData[workoutName].reduce((prevWorkout, workout) => {
-    return prevWorkout.totalCount >= workout.totalCount ? prevWorkout : workout;
-  }).month;
+  const MOST_WORKOUT_MONTH = allMonthWorkoutCountData[workoutName].reduce(
+    (prevWorkout, workout) => {
+      return prevWorkout.totalCount >= workout.totalCount ? prevWorkout : workout;
+    },
+  ).month;
 
   const handleDropdownItemClick = ({ currentTarget }: MouseEvent<HTMLButtonElement>) => {
     const selectedWorkoutName = currentTarget.name as WorkoutNames;
     setWorkoutName(selectedWorkoutName);
   };
 
+  const monthWorkoutCountData = allMonthWorkoutCountData[workoutName].map(
+    ({ month, totalCount }) => {
+      return {
+        월: MONTH_NAME_IN_KOREAN[month],
+        '운동 횟수': totalCount,
+      };
+    },
+  );
+
   return (
     <section className="w-full pb-8 pt-5">
       <MonthDropdown handleDropdownItemClick={handleDropdownItemClick} workoutName={workoutName} />
       <div className="flex w-full flex-col items-center bg-gray-6 py-4">
         <p className="pb-4 text-center text-xs">
-          <span className="text-primary">
-            {FULL_MONTH_NAME_BY_ABBREVIATION[MOST_WORKOUT_MONTH]}
-          </span>
-          에 {workoutName}을 가장 많이 하셨어요!
+          <span className="text-primary">{MONTH_NAME_IN_KOREAN[MOST_WORKOUT_MONTH]}</span>에{' '}
+          {workoutName}을 가장 많이 하셨어요!
         </p>
-        <LineChart width={350} height={350} data={monthWorkoutCountData[workoutName]}>
+        <LineChart width={350} height={350} data={monthWorkoutCountData}>
           <CartesianGrid strokeDasharray="3 3" />
-          <XAxis dataKey="month" />
+          <XAxis dataKey="월" />
           <YAxis />
           <Tooltip
             labelFormatter={(value) => {
-              return `month : ${value}`;
+              return value;
             }}
             labelStyle={{ color: COLOR_BY_WORKOUT[workoutName] }}
             contentStyle={{
@@ -66,7 +75,7 @@ export const MonthlyTotalCountByEachWorkoutChart = () => {
           <Legend />
           <Line
             type="monotone"
-            dataKey="totalCount"
+            dataKey="운동 횟수"
             dot={false}
             stroke={COLOR_BY_WORKOUT[workoutName]}
           />

--- a/src/pages/Summary/MonthlyTotalCountByEachWorkoutChart/index.tsx
+++ b/src/pages/Summary/MonthlyTotalCountByEachWorkoutChart/index.tsx
@@ -69,7 +69,10 @@ export const MonthlyTotalCountByEachWorkoutChart = () => {
             }}
             labelStyle={{ color: COLOR_BY_WORKOUT[workoutName] }}
             contentStyle={{
-              paddingRight: '20px',
+              display: 'flex',
+              alignItems: 'center',
+              gap: '3px',
+              paddingRight: '10px',
             }}
           />
           <Legend />

--- a/src/pages/Summary/MonthlyTotalCountByEachWorkoutChart/index.tsx
+++ b/src/pages/Summary/MonthlyTotalCountByEachWorkoutChart/index.tsx
@@ -23,15 +23,13 @@ export const MonthlyTotalCountByEachWorkoutChart = () => {
   const [workoutName, setWorkoutName] = useState<WorkoutNames>('Hanging');
   const [accessToken, setAccessToken] = useAtom(accessTokenAtom);
   const setModalType = useSetAtom(modalTypeAtom);
-  const { data: monthWorkoutCountData } = useGetMonthWorkoutCount(
-    accessToken,
-    setAccessToken,
-    setModalType,
-  );
+  const { data } = useGetMonthWorkoutCount(accessToken, setAccessToken, setModalType);
 
-  if (!monthWorkoutCountData) {
+  if (!data) {
     return null;
   }
+
+  const { data: monthWorkoutCountData } = data;
 
   const MOST_WORKOUT_MONTH = monthWorkoutCountData[workoutName].reduce((prevWorkout, workout) => {
     return prevWorkout.totalCount >= workout.totalCount ? prevWorkout : workout;

--- a/src/pages/Summary/TotalCountByAllWorkoutsChart/index.tsx
+++ b/src/pages/Summary/TotalCountByAllWorkoutsChart/index.tsx
@@ -16,14 +16,14 @@ export const TotalCountByAllWorkoutsChart = () => {
 
   const { totalCountByWorkout: totalCountByWorkoutData } = data;
 
-  const MOST_WORKOUT_NAME = totalCountByWorkoutData.reduce((prevWorkoutData, workoutData) => {
+  const mostCommonWorkoutName = totalCountByWorkoutData.reduce((prevWorkoutData, workoutData) => {
     return prevWorkoutData.totalCount >= workoutData.totalCount ? prevWorkoutData : workoutData;
   }).workout;
 
   return (
     <section className="flex w-full flex-col items-center bg-gray-6 py-4">
       <p className="text-center text-xs">
-        <span className="text-primary">{MOST_WORKOUT_NAME}</span>을 가장 많이 하셨어요!
+        <span className="text-primary">{mostCommonWorkoutName}</span>을 가장 많이 하셨어요!
       </p>
       <RadarChart outerRadius={70} width={350} height={230} data={totalCountByWorkoutData}>
         <PolarGrid />


### PR DESCRIPTION
## Issues
- Issue number #116 

## Tasks Done 
- API 인터페이스의 변경 사항 적용
  - [x] 월별 풀업 운동 횟수 데이터 API의 인터페이스 변경 사항 적용
  - [x] 운동 시간대별 완료된 플랜 갯수 데이터 API의 인터페이스 변경 사항 적용
- 영어 이름을 한글 이름으로 변경
  - [x] 월별 풀업 운동 횟수 그래프의 X, Y 축, 문구를 한글로 변경
  - [x] 운동 시간대별 완료된 플랜 갯수 그래프의 X, Y 축, 문구를 한글로 변경

<br>

## Description
### 월별 풀업 운동 횟수 데이터 API의 인터페이스 변경 사항 적용
- "data" 키와 기존 데이터 값을 가진 객체 형태의 데이터로 변경했습니다.
- "month" 키에 대한 값을 달 영어 이름 대문자 3글자로 변경했습니다. ("Jun" => "JUN")

```json
{
    "data": {
        "Hanging": [
            {
                "month": "JUN",
                "totalCount": 0
            },
            {
                "month": "JUL",
                "totalCount": 0
            },
            {
                "month": "AUG",
                "totalCount": 0
            },
            {
                "month": "SEP",
                "totalCount": 0
            },
            {
                "month": "OCT",
                "totalCount": 0
            },
            {
                "month": "NOV",
                "totalCount": 0
            }
        ],
        ...
    }
}
```

### 월별 풀업 운동 횟수 그래프의 X, Y 축, 문구를 한글로 변경
- Pullanner 서비스의 주 타겟층이 한국인이므로, 그래프의 X, Y 축, 문구를 한글로 변경했습니다.
- 문구에서 달에 대한 전체 영어 이름을 사용하기 위해 만든 객체 `FULL_MONTH_NAME_BY_ABBREVIATION`를 없애고, 달에 대한 한글 이름을 가진 객체 `MONTH_NAME_IN_KOREAN`를 만들어서 사용했습니다.
- 월별 풀업 운동 횟수 그래프의 X, Y 축인 "month", "totalCount"를 "월", "운동 횟수"로 변경했습니다.
- `MONTH_NAME_IN_KOREAN` 통해 월별 풀업 운동 횟수 그래프의 X 축 값인 달 이름을 한글로 변경했습니다.
- tooltip에서 달 이름을 한글로 작성하니까 여백이 많이 남아서, 달 이름과 운동 횟수를 flex 박스로 감싸서 한 줄로 변경했습니다.

### 운동 시간대별 완료된 플랜 갯수 데이터 API의 인터페이스 변경 사항 적용
- 화면에서 명시한 운동 시간대와 실제 운동 시간대가 달라서 혼돈을 줄 수 있다고 생각하여 하루에 대한 운동 시간대를 4로 나누는 것을 제안했습니다. [참고](https://www.notion.so/dev-millie/Summary-API-e3f1cfaac4de4f0baa009ad987214e9e)
- 기존 운동 시간대(moring, afternoon, evening)에서 night를 추가했습니다.
- 운동 시간대의 시간 범위를 아래와 같이 수정했습니다.
  - night : 00:00 ~ 05:59
  - morning : 06:00 ~ 11:59
  - afternoon : 12:00 ~ 17:59
  - evening : 18:00 ~ 23:59

```json
{
 "completedPlanCountByTime" : [
    {
      "time": "night",
      "thisMonth": 40,
      "prevMonth": 45,
    },
    {
      "time": "morning",
      "thisMonth": 20,
      "prevMonth": 10,
    },
    {
      "time": "afternoon",
      "thisMonth": 30,
      "prevMonth": 35,
    },
    {
      "time": "evening",
      "thisMonth": 70,
      "prevMonth": 55,
    },
  ],
}
```

### 운동 시간대별 완료된 플랜 갯수 그래프의 X, Y 축, 문구를 한글로 변경
- Pullanner 서비스의 주 타겟층이 한국인이므로, 그래프의 X, Y 축, 문구를 한글로 변경했습니다.
- 시간대에 대한 한글 이름을 가진 객체 `TIME_NAME_IN_KOREAN`를 만들어서 사용했습니다.
- 운동 시간대별 완료된 플랜 갯수 그래프의 X, Y1, Y2 축인 "time", "thisMonth", "prevMonth"를 "시간대", "이번달 플랜수", "저번달 플랜수"로 변경했습니다.
- `TIME_NAME_IN_KOREAN`를 통해 운동 시간대별 완료된 플랜 갯수 그래프의 X 축 값인 운동 시간대를 한글로 변경했습니다.
- 운동 시간대별 완료된 플랜 갯수 그래프의 width를 350에서 330으로 줄였습니다.

<br>

## Visuals
### 월별 풀업 운동 횟수 그래프

<img width="188" alt="image" src="https://github.com/Pullanner/pullanner-web/assets/70058081/5757838b-8855-4284-b2a0-3b06eb92e9f9">
<img width="189" alt="스크린샷 2023-11-08 163629" src="https://github.com/Pullanner/pullanner-web/assets/70058081/1b9d8219-0f17-488d-9c74-9efece7235b2">

### 운동 시간대별 완료된 플랜 갯수 그래프

<img width="224" alt="image" src="https://github.com/Pullanner/pullanner-web/assets/70058081/077e7f87-895b-4d14-b047-1f3575c35ba3">
<img width="223" alt="image" src="https://github.com/Pullanner/pullanner-web/assets/70058081/401dca58-cf57-4d70-99a6-1acdafd5e077">
