### PR TITLE
[#116] Fix: change Up to up suffix of workoutName to match variable with server data

### DIFF
--- a/src/constants/summary.ts
+++ b/src/constants/summary.ts
@@ -1,12 +1,12 @@
 export const COLOR_BY_WORKOUT = {
   Hanging: '#F47C7C',
-  'Jumping Pull-Up': '#F1B55B',
-  'Band Pull-Up': '#DFE152',
-  'Chin-Up': '#8EE14E',
-  'Pull-Up': '#60EBD1',
+  'Jumping Pull-up': '#F1B55B',
+  'Band Pull-up': '#DFE152',
+  'Chin-up': '#8EE14E',
+  'Pull-up': '#60EBD1',
   'Chest to Bar': '#8BB3FF',
-  'Archer Pull-Up': '#CD7BFF',
-  'Muscle Up': '#FF8CF4',
+  'Archer Pull-up': '#CD7BFF',
+  'Muscle up': '#FF8CF4',
 } as const;
 
 export const MONTH_NAME_IN_KOREAN = {

--- a/src/mocks/summaries/monthWorkoutCount/data.ts
+++ b/src/mocks/summaries/monthWorkoutCount/data.ts
@@ -2,13 +2,13 @@ import { MONTH_NAME_IN_KOREAN } from '@/constants';
 
 type WorkoutNames =
   | 'Hanging'
-  | 'Jumping Pull-Up'
-  | 'Band Pull-Up'
-  | 'Chin-Up'
-  | 'Pull-Up'
+  | 'Jumping Pull-up'
+  | 'Band Pull-up'
+  | 'Chin-up'
+  | 'Pull-up'
   | 'Chest to Bar'
-  | 'Archer Pull-Up'
-  | 'Muscle Up';
+  | 'Archer Pull-up'
+  | 'Muscle up';
 
 export type MonthWorkoutCount = {
   data: {
@@ -47,7 +47,7 @@ export const MONTH_WORKOUT_COUNT_DATA = {
         totalCount: 100,
       },
     ],
-    'Jumping Pull-Up': [
+    'Jumping Pull-up': [
       {
         month: 'MAY',
         totalCount: 300,
@@ -73,7 +73,7 @@ export const MONTH_WORKOUT_COUNT_DATA = {
         totalCount: 100,
       },
     ],
-    'Band Pull-Up': [
+    'Band Pull-up': [
       {
         month: 'MAY',
         totalCount: 500,
@@ -99,7 +99,7 @@ export const MONTH_WORKOUT_COUNT_DATA = {
         totalCount: 200,
       },
     ],
-    'Chin-Up': [
+    'Chin-up': [
       {
         month: 'MAY',
         totalCount: 100,
@@ -125,7 +125,7 @@ export const MONTH_WORKOUT_COUNT_DATA = {
         totalCount: 200,
       },
     ],
-    'Pull-Up': [
+    'Pull-up': [
       {
         month: 'MAY',
         totalCount: 100,
@@ -177,7 +177,7 @@ export const MONTH_WORKOUT_COUNT_DATA = {
         totalCount: 500,
       },
     ],
-    'Archer Pull-Up': [
+    'Archer Pull-up': [
       {
         month: 'MAY',
         totalCount: 500,
@@ -203,7 +203,7 @@ export const MONTH_WORKOUT_COUNT_DATA = {
         totalCount: 100,
       },
     ],
-    'Muscle Up': [
+    'Muscle up': [
       {
         month: 'MAY',
         totalCount: 300,

--- a/src/mocks/summaries/totalWorkoutCount/data.ts
+++ b/src/mocks/summaries/totalWorkoutCount/data.ts
@@ -1,13 +1,13 @@
 export const TOTAL_WORKOUT_COUNT_DATA = {
   totalCountByWorkout: [
     { workout: 'Hanging', totalCount: 600 },
-    { workout: 'Jumping Pull-Up', totalCount: 500 },
-    { workout: 'Band Pull-Up', totalCount: 300 },
-    { workout: 'Chin-Up', totalCount: 200 },
-    { workout: 'Pull-Up', totalCount: 100 },
+    { workout: 'Jumping Pull-up', totalCount: 500 },
+    { workout: 'Band Pull-up', totalCount: 300 },
+    { workout: 'Chin-up', totalCount: 200 },
+    { workout: 'Pull-up', totalCount: 100 },
     { workout: 'Chest to Bar', totalCount: 50 },
-    { workout: 'Archer Pull-Up', totalCount: 0 },
-    { workout: 'Muscle Up', totalCount: 0 },
+    { workout: 'Archer Pull-up', totalCount: 0 },
+    { workout: 'Muscle up', totalCount: 0 },
   ],
 };
 

--- a/src/pages/Summary/MonthlyTotalCountByEachWorkoutChart/MonthDropdown.tsx
+++ b/src/pages/Summary/MonthlyTotalCountByEachWorkoutChart/MonthDropdown.tsx
@@ -23,32 +23,32 @@ export const MonthDropdown = ({ handleDropdownItemClick, workoutName }: MonthDro
     {
       key: '2',
       label: (
-        <button type="button" name="Jumping Pull-Up" onClick={handleDropdownItemClick}>
-          Jumping Pull-Up
+        <button type="button" name="Jumping Pull-up" onClick={handleDropdownItemClick}>
+          Jumping Pull-up
         </button>
       ),
     },
     {
       key: '3',
       label: (
-        <button type="button" name="Band Pull-Up" onClick={handleDropdownItemClick}>
-          Band Pull-Up
+        <button type="button" name="Band Pull-up" onClick={handleDropdownItemClick}>
+          Band Pull-up
         </button>
       ),
     },
     {
       key: '4',
       label: (
-        <button type="button" name="Chin-Up" onClick={handleDropdownItemClick}>
-          Chin-Up
+        <button type="button" name="Chin-up" onClick={handleDropdownItemClick}>
+          Chin-up
         </button>
       ),
     },
     {
       key: '5',
       label: (
-        <button type="button" name="Pull-Up" onClick={handleDropdownItemClick}>
-          Pull-Up
+        <button type="button" name="Pull-up" onClick={handleDropdownItemClick}>
+          Pull-up
         </button>
       ),
     },
@@ -63,16 +63,16 @@ export const MonthDropdown = ({ handleDropdownItemClick, workoutName }: MonthDro
     {
       key: '7',
       label: (
-        <button type="button" name="Archer Pull-Up" onClick={handleDropdownItemClick}>
-          Archer Pull-Up
+        <button type="button" name="Archer Pull-up" onClick={handleDropdownItemClick}>
+          Archer Pull-up
         </button>
       ),
     },
     {
       key: '8',
       label: (
-        <button type="button" name="Muscle Up" onClick={handleDropdownItemClick}>
-          Muscle Up
+        <button type="button" name="Muscle up" onClick={handleDropdownItemClick}>
+          Muscle up
         </button>
       ),
     },

--- a/src/pages/Summary/MonthlyTotalCountByEachWorkoutChart/index.tsx
+++ b/src/pages/Summary/MonthlyTotalCountByEachWorkoutChart/index.tsx
@@ -11,13 +11,13 @@ import { MonthDropdown } from './MonthDropdown';
 
 type WorkoutNames =
   | 'Hanging'
-  | 'Jumping Pull-Up'
-  | 'Band Pull-Up'
-  | 'Chin-Up'
-  | 'Pull-Up'
+  | 'Jumping Pull-up'
+  | 'Band Pull-up'
+  | 'Chin-up'
+  | 'Pull-up'
   | 'Chest to Bar'
-  | 'Archer Pull-Up'
-  | 'Muscle Up';
+  | 'Archer Pull-up'
+  | 'Muscle up';
 
 export const MonthlyTotalCountByEachWorkoutChart = () => {
   const [workoutName, setWorkoutName] = useState<WorkoutNames>('Hanging');


### PR DESCRIPTION
## Issues
- Issue number #118 

## Tasks Done 
- [x] **workoutName** 중 -`Up`으로 끝나는 운동 이름을 `-up`으로 수정

## Description
- `Summary` 페이지의 월별 풀업 운동 횟수 그래프의 **workoutName**이 서버의 데이터와 일치하지 않아서 에러가 발생했습니다.
  - 배경 : MonthDropdown에서 클릭한 아이템의 이름을 workoutName으로 설정하여, 해당 workoutName에 대한 월별 풀업 운동 횟수 데이터를 그래프에 그리려고 했습니다.
  - 원인 : 코드 상의 workoutName과 서버 데이터의 workoutName이 같지 않아서, 해당 workoutName에 대한 월별 풀업 운동 횟수 데이터가 `undefined`로 나오는 에러가 발생했습니다.
  - 해결 : 코드 상의 workoutName과 서버 데이터의 workoutName을 같게 만들어서 에러를 해결했습니다.

```ts
// MonthlyTotalCountByEachWorkoutChart.tsx
type WorkoutNames =
  | 'Hanging'
  | 'Jumping Pull-Up'
  | 'Band Pull-Up'
  | 'Chin-Up'
  | 'Pull-Up'
  | 'Chest to Bar'
  | 'Archer Pull-Up'
  | 'Muscle Up';

const [workoutName, setWorkoutName] = useState<WorkoutNames>('Hanging');

const handleDropdownItemClick = ({ currentTarget }: MouseEvent<HTMLButtonElement>) => {
  const selectedWorkoutName = currentTarget.name as WorkoutNames;
  setWorkoutName(selectedWorkoutName);
};

// TypeError: Cannot read properties of undefined (reading 'reduce')
const monthWithTheMostWorkout = allMonthWorkoutCountData[workoutName].reduce(
  (prevWorkout, workout) => {
    return prevWorkout.totalCount >= workout.totalCount ? prevWorkout : workout;
  },
).month;
```

```json
// 실제 데이터
{
 "data": {
    "Hanging": [...],
    "Jumping Pull-up": [...],
    "Chin-up": [...],
    "Pull-up": [...],
    "Chest to Bar": [...],
    "Archer Pull-up": [...],
    "Muscle up": [...],
  }
}
```
