### PR TITLE
Refactor/#121 summary

### DIFF
--- a/src/components/cards/SelectableWorkoutCard/index.tsx
+++ b/src/components/cards/SelectableWorkoutCard/index.tsx
@@ -1,7 +1,8 @@
 import { useSetAtom } from 'jotai';
 import { useState } from 'react';
 
-import { workoutDataAtom, WorkoutId } from '@/stores/atoms/workoutDataAtom';
+import { workoutDataAtom } from '@/stores/atoms/workoutDataAtom';
+import { StepIdForWorkout } from '@/types/workout';
 
 import { WorkoutCard, WorkoutCardProps } from '../WorkoutCard';
 
@@ -26,11 +27,11 @@ export const SelectableWorkoutCard = ({
   const setWorkoutData = useSetAtom(workoutDataAtom);
 
   const handleCardClick = ({ currentTarget }: MouseEvent<HTMLButtonElement>) => {
-    const cardId = Number(currentTarget.id) as WorkoutId;
+    const cardId = Number(currentTarget.id) as StepIdForWorkout;
 
     setWorkoutData((prevWorkoutData) => {
       const hasCardId = prevWorkoutData.has(cardId);
-      const newWorkoutData = new Set<WorkoutId>(prevWorkoutData.values());
+      const newWorkoutData = new Set<StepIdForWorkout>(prevWorkoutData.values());
 
       if (hasCardId) {
         newWorkoutData.delete(cardId);

--- a/src/constants/summary.ts
+++ b/src/constants/summary.ts
@@ -1,14 +1,3 @@
-export const COLOR_BY_WORKOUT = {
-  Hanging: '#F47C7C',
-  'Jumping Pull-up': '#F1B55B',
-  'Band Pull-up': '#DFE152',
-  'Chin-up': '#8EE14E',
-  'Pull-up': '#60EBD1',
-  'Chest to Bar': '#8BB3FF',
-  'Archer Pull-up': '#CD7BFF',
-  'Muscle up': '#FF8CF4',
-} as const;
-
 export const MONTH_NAME_IN_KOREAN = {
   JAN: '1월',
   FEB: '2월',

--- a/src/mocks/summaries/monthWorkoutCount/data.ts
+++ b/src/mocks/summaries/monthWorkoutCount/data.ts
@@ -1,233 +1,248 @@
 import { MONTH_NAME_IN_KOREAN } from '@/constants';
 
-type WorkoutNames =
-  | 'Hanging'
-  | 'Jumping Pull-up'
-  | 'Band Pull-up'
-  | 'Chin-up'
-  | 'Pull-up'
-  | 'Chest to Bar'
-  | 'Archer Pull-up'
-  | 'Muscle up';
-
 export type MonthWorkoutCount = {
-  data: {
-    [K in WorkoutNames]: {
+  workoutCountPerMonth: {
+    step: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
+    data: {
       month: keyof typeof MONTH_NAME_IN_KOREAN;
       totalCount: number;
     }[];
-  };
+  }[];
 };
 
-export const MONTH_WORKOUT_COUNT_DATA = {
-  data: {
-    Hanging: [
-      {
-        month: 'MAY',
-        totalCount: 200,
-      },
-      {
-        month: 'JUN',
-        totalCount: 300,
-      },
-      {
-        month: 'JUL',
-        totalCount: 400,
-      },
-      {
-        month: 'AUG',
-        totalCount: 300,
-      },
-      {
-        month: 'SEP',
-        totalCount: 200,
-      },
-      {
-        month: 'OCT',
-        totalCount: 100,
-      },
-    ],
-    'Jumping Pull-up': [
-      {
-        month: 'MAY',
-        totalCount: 300,
-      },
-      {
-        month: 'JUN',
-        totalCount: 400,
-      },
-      {
-        month: 'JUL',
-        totalCount: 300,
-      },
-      {
-        month: 'AUG',
-        totalCount: 200,
-      },
-      {
-        month: 'SEP',
-        totalCount: 100,
-      },
-      {
-        month: 'OCT',
-        totalCount: 100,
-      },
-    ],
-    'Band Pull-up': [
-      {
-        month: 'MAY',
-        totalCount: 500,
-      },
-      {
-        month: 'JUN',
-        totalCount: 400,
-      },
-      {
-        month: 'JUL',
-        totalCount: 300,
-      },
-      {
-        month: 'AUG',
-        totalCount: 200,
-      },
-      {
-        month: 'SEP',
-        totalCount: 100,
-      },
-      {
-        month: 'OCT',
-        totalCount: 200,
-      },
-    ],
-    'Chin-up': [
-      {
-        month: 'MAY',
-        totalCount: 100,
-      },
-      {
-        month: 'JUN',
-        totalCount: 200,
-      },
-      {
-        month: 'JUL',
-        totalCount: 300,
-      },
-      {
-        month: 'AUG',
-        totalCount: 400,
-      },
-      {
-        month: 'SEP',
-        totalCount: 300,
-      },
-      {
-        month: 'OCT',
-        totalCount: 200,
-      },
-    ],
-    'Pull-up': [
-      {
-        month: 'MAY',
-        totalCount: 100,
-      },
-      {
-        month: 'JUN',
-        totalCount: 100,
-      },
-      {
-        month: 'JUL',
-        totalCount: 200,
-      },
-      {
-        month: 'AUG',
-        totalCount: 300,
-      },
-      {
-        month: 'SEP',
-        totalCount: 400,
-      },
-      {
-        month: 'OCT',
-        totalCount: 300,
-      },
-    ],
-    'Chest to Bar Pull-up': [
-      {
-        month: 'MAY',
-        totalCount: 200,
-      },
-      {
-        month: 'JUN',
-        totalCount: 100,
-      },
-      {
-        month: 'JUL',
-        totalCount: 200,
-      },
-      {
-        month: 'AUG',
-        totalCount: 300,
-      },
-      {
-        month: 'SEP',
-        totalCount: 400,
-      },
-      {
-        month: 'OCT',
-        totalCount: 500,
-      },
-    ],
-    'Archer Pull-up': [
-      {
-        month: 'MAY',
-        totalCount: 500,
-      },
-      {
-        month: 'JUN',
-        totalCount: 300,
-      },
-      {
-        month: 'JUL',
-        totalCount: 400,
-      },
-      {
-        month: 'AUG',
-        totalCount: 300,
-      },
-      {
-        month: 'SEP',
-        totalCount: 200,
-      },
-      {
-        month: 'OCT',
-        totalCount: 100,
-      },
-    ],
-    'Muscle up': [
-      {
-        month: 'MAY',
-        totalCount: 300,
-      },
-      {
-        month: 'JUN',
-        totalCount: 450,
-      },
-      {
-        month: 'JUL',
-        totalCount: 400,
-      },
-      {
-        month: 'AUG',
-        totalCount: 300,
-      },
-      {
-        month: 'SEP',
-        totalCount: 200,
-      },
-      {
-        month: 'OCT',
-        totalCount: 200,
-      },
-    ],
-  },
+export const MONTH_WORKOUT_COUNT_DATA: MonthWorkoutCount = {
+  workoutCountPerMonth: [
+    {
+      step: 1,
+      data: [
+        {
+          month: 'MAY',
+          totalCount: 200,
+        },
+        {
+          month: 'JUN',
+          totalCount: 300,
+        },
+        {
+          month: 'JUL',
+          totalCount: 400,
+        },
+        {
+          month: 'AUG',
+          totalCount: 300,
+        },
+        {
+          month: 'SEP',
+          totalCount: 200,
+        },
+        {
+          month: 'OCT',
+          totalCount: 100,
+        },
+      ],
+    },
+    {
+      step: 2,
+      data: [
+        {
+          month: 'MAY',
+          totalCount: 300,
+        },
+        {
+          month: 'JUN',
+          totalCount: 400,
+        },
+        {
+          month: 'JUL',
+          totalCount: 300,
+        },
+        {
+          month: 'AUG',
+          totalCount: 200,
+        },
+        {
+          month: 'SEP',
+          totalCount: 100,
+        },
+        {
+          month: 'OCT',
+          totalCount: 100,
+        },
+      ],
+    },
+    {
+      step: 3,
+      data: [
+        {
+          month: 'MAY',
+          totalCount: 500,
+        },
+        {
+          month: 'JUN',
+          totalCount: 400,
+        },
+        {
+          month: 'JUL',
+          totalCount: 300,
+        },
+        {
+          month: 'AUG',
+          totalCount: 200,
+        },
+        {
+          month: 'SEP',
+          totalCount: 100,
+        },
+        {
+          month: 'OCT',
+          totalCount: 200,
+        },
+      ],
+    },
+    {
+      step: 4,
+      data: [
+        {
+          month: 'MAY',
+          totalCount: 100,
+        },
+        {
+          month: 'JUN',
+          totalCount: 200,
+        },
+        {
+          month: 'JUL',
+          totalCount: 300,
+        },
+        {
+          month: 'AUG',
+          totalCount: 400,
+        },
+        {
+          month: 'SEP',
+          totalCount: 300,
+        },
+        {
+          month: 'OCT',
+          totalCount: 200,
+        },
+      ],
+    },
+    {
+      step: 5,
+      data: [
+        {
+          month: 'MAY',
+          totalCount: 100,
+        },
+        {
+          month: 'JUN',
+          totalCount: 100,
+        },
+        {
+          month: 'JUL',
+          totalCount: 200,
+        },
+        {
+          month: 'AUG',
+          totalCount: 300,
+        },
+        {
+          month: 'SEP',
+          totalCount: 400,
+        },
+        {
+          month: 'OCT',
+          totalCount: 300,
+        },
+      ],
+    },
+    {
+      step: 6,
+      data: [
+        {
+          month: 'MAY',
+          totalCount: 200,
+        },
+        {
+          month: 'JUN',
+          totalCount: 100,
+        },
+        {
+          month: 'JUL',
+          totalCount: 200,
+        },
+        {
+          month: 'AUG',
+          totalCount: 300,
+        },
+        {
+          month: 'SEP',
+          totalCount: 400,
+        },
+        {
+          month: 'OCT',
+          totalCount: 500,
+        },
+      ],
+    },
+    {
+      step: 7,
+      data: [
+        {
+          month: 'MAY',
+          totalCount: 500,
+        },
+        {
+          month: 'JUN',
+          totalCount: 300,
+        },
+        {
+          month: 'JUL',
+          totalCount: 400,
+        },
+        {
+          month: 'AUG',
+          totalCount: 300,
+        },
+        {
+          month: 'SEP',
+          totalCount: 200,
+        },
+        {
+          month: 'OCT',
+          totalCount: 100,
+        },
+      ],
+    },
+    {
+      step: 8,
+      data: [
+        {
+          month: 'MAY',
+          totalCount: 300,
+        },
+        {
+          month: 'JUN',
+          totalCount: 450,
+        },
+        {
+          month: 'JUL',
+          totalCount: 400,
+        },
+        {
+          month: 'AUG',
+          totalCount: 300,
+        },
+        {
+          month: 'SEP',
+          totalCount: 200,
+        },
+        {
+          month: 'OCT',
+          totalCount: 200,
+        },
+      ],
+    },
+  ],
 };

--- a/src/mocks/summaries/monthWorkoutCount/data.ts
+++ b/src/mocks/summaries/monthWorkoutCount/data.ts
@@ -1,8 +1,9 @@
 import { MONTH_NAME_IN_KOREAN } from '@/constants';
+import { StepIdForWorkout } from '@/types/workout';
 
 export type MonthWorkoutCount = {
   workoutCountPerMonth: {
-    step: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
+    step: StepIdForWorkout;
     data: {
       month: keyof typeof MONTH_NAME_IN_KOREAN;
       totalCount: number;

--- a/src/mocks/summaries/totalWorkoutCount/data.ts
+++ b/src/mocks/summaries/totalWorkoutCount/data.ts
@@ -1,14 +1,19 @@
-export const TOTAL_WORKOUT_COUNT_DATA = {
-  totalCountByWorkout: [
-    { workout: 'Hanging', totalCount: 600 },
-    { workout: 'Jumping Pull-up', totalCount: 500 },
-    { workout: 'Band Pull-up', totalCount: 300 },
-    { workout: 'Chin-up', totalCount: 200 },
-    { workout: 'Pull-up', totalCount: 100 },
-    { workout: 'Chest to Bar', totalCount: 50 },
-    { workout: 'Archer Pull-up', totalCount: 0 },
-    { workout: 'Muscle up', totalCount: 0 },
-  ],
+export type TotalWorkoutCount = {
+  totalCountByWorkout: {
+    step: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
+    totalCount: number;
+  }[];
 };
 
-export type TotalWorkoutCount = typeof TOTAL_WORKOUT_COUNT_DATA;
+export const TOTAL_WORKOUT_COUNT_DATA: TotalWorkoutCount = {
+  totalCountByWorkout: [
+    { step: 1, totalCount: 600 },
+    { step: 2, totalCount: 500 },
+    { step: 3, totalCount: 300 },
+    { step: 4, totalCount: 200 },
+    { step: 5, totalCount: 100 },
+    { step: 6, totalCount: 50 },
+    { step: 7, totalCount: 0 },
+    { step: 8, totalCount: 0 },
+  ],
+};

--- a/src/mocks/summaries/totalWorkoutCount/data.ts
+++ b/src/mocks/summaries/totalWorkoutCount/data.ts
@@ -1,6 +1,8 @@
+import { StepIdForWorkout } from '@/types/workout';
+
 export type TotalWorkoutCount = {
   totalCountByWorkout: {
-    step: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
+    step: StepIdForWorkout;
     totalCount: number;
   }[];
 };

--- a/src/mocks/users/workouts/data.ts
+++ b/src/mocks/users/workouts/data.ts
@@ -1,6 +1,7 @@
+import { StepIdForWorkout } from '@/types/workout';
+
 export const WORKOUT_DATA = {
   workouts: [1],
 };
 
-type WorkoutId = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
-export type Workouts = WorkoutId[];
+export type Workouts = StepIdForWorkout[];

--- a/src/pages/SetupResult/WorkoutResult.tsx
+++ b/src/pages/SetupResult/WorkoutResult.tsx
@@ -1,7 +1,8 @@
 import { WorkoutCard } from '@/components/cards/WorkoutCard';
+import { StepIdForWorkout } from '@/types/workout';
 
 type WorkoutInfo = {
-  id: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
+  id: StepIdForWorkout;
   imageSrc: string;
   name: string;
   difficulty: number;

--- a/src/pages/Summary/MonthlyTotalCountByEachWorkoutChart/MonthDropdown.tsx
+++ b/src/pages/Summary/MonthlyTotalCountByEachWorkoutChart/MonthDropdown.tsx
@@ -1,21 +1,23 @@
 import { Dropdown, ConfigProvider, type MenuProps } from 'antd';
 import { type MouseEvent } from 'react';
 
+import { WORKOUT_NAME } from '@/constants';
 import { DownArrowIcon } from '@/icons/DownArrowIcon';
+import { StepIdForWorkout } from '@/types/workout';
 
 import { CUSTOM_COLOR_TOKEN } from './customColorToken';
 
 type MonthDropdownProps = {
   handleDropdownItemClick: ({ currentTarget }: MouseEvent<HTMLButtonElement>) => void;
-  workoutName: string;
+  stepId: StepIdForWorkout;
 };
 
-export const MonthDropdown = ({ handleDropdownItemClick, workoutName }: MonthDropdownProps) => {
+export const MonthDropdown = ({ handleDropdownItemClick, stepId }: MonthDropdownProps) => {
   const items: MenuProps['items'] = [
     {
       key: '1',
       label: (
-        <button type="button" name="Hanging" onClick={handleDropdownItemClick}>
+        <button type="button" id="1" onClick={handleDropdownItemClick}>
           Hanging
         </button>
       ),
@@ -23,7 +25,7 @@ export const MonthDropdown = ({ handleDropdownItemClick, workoutName }: MonthDro
     {
       key: '2',
       label: (
-        <button type="button" name="Jumping Pull-up" onClick={handleDropdownItemClick}>
+        <button type="button" id="2" onClick={handleDropdownItemClick}>
           Jumping Pull-up
         </button>
       ),
@@ -31,7 +33,7 @@ export const MonthDropdown = ({ handleDropdownItemClick, workoutName }: MonthDro
     {
       key: '3',
       label: (
-        <button type="button" name="Band Pull-up" onClick={handleDropdownItemClick}>
+        <button type="button" id="3" onClick={handleDropdownItemClick}>
           Band Pull-up
         </button>
       ),
@@ -39,7 +41,7 @@ export const MonthDropdown = ({ handleDropdownItemClick, workoutName }: MonthDro
     {
       key: '4',
       label: (
-        <button type="button" name="Chin-up" onClick={handleDropdownItemClick}>
+        <button type="button" id="4" onClick={handleDropdownItemClick}>
           Chin-up
         </button>
       ),
@@ -47,7 +49,7 @@ export const MonthDropdown = ({ handleDropdownItemClick, workoutName }: MonthDro
     {
       key: '5',
       label: (
-        <button type="button" name="Pull-up" onClick={handleDropdownItemClick}>
+        <button type="button" id="5" onClick={handleDropdownItemClick}>
           Pull-up
         </button>
       ),
@@ -55,7 +57,7 @@ export const MonthDropdown = ({ handleDropdownItemClick, workoutName }: MonthDro
     {
       key: '6',
       label: (
-        <button type="button" name="Chest to Bar" onClick={handleDropdownItemClick}>
+        <button type="button" id="6" onClick={handleDropdownItemClick}>
           Chest to Bar
         </button>
       ),
@@ -63,7 +65,7 @@ export const MonthDropdown = ({ handleDropdownItemClick, workoutName }: MonthDro
     {
       key: '7',
       label: (
-        <button type="button" name="Archer Pull-up" onClick={handleDropdownItemClick}>
+        <button type="button" id="7" onClick={handleDropdownItemClick}>
           Archer Pull-up
         </button>
       ),
@@ -71,7 +73,7 @@ export const MonthDropdown = ({ handleDropdownItemClick, workoutName }: MonthDro
     {
       key: '8',
       label: (
-        <button type="button" name="Muscle up" onClick={handleDropdownItemClick}>
+        <button type="button" id="8" onClick={handleDropdownItemClick}>
           Muscle up
         </button>
       ),
@@ -84,7 +86,7 @@ export const MonthDropdown = ({ handleDropdownItemClick, workoutName }: MonthDro
         <Dropdown menu={{ items, selectable: true }} placement="bottomLeft" trigger={['click']}>
           <div className="inline-block rounded-md bg-gray-4 px-2.5 py-1.5 text-sm hover:bg-gray-3">
             <div className="flex items-center justify-center gap-2">
-              <span>{workoutName}</span>
+              <span>{WORKOUT_NAME[stepId]}</span>
               <DownArrowIcon />
             </div>
           </div>

--- a/src/pages/Summary/TotalCountByAllWorkoutsChart/index.tsx
+++ b/src/pages/Summary/TotalCountByAllWorkoutsChart/index.tsx
@@ -1,6 +1,7 @@
 import { useAtom, useSetAtom } from 'jotai';
 import { PolarAngleAxis, PolarGrid, PolarRadiusAxis, Radar, RadarChart } from 'recharts';
 
+import { WORKOUT_NAME } from '@/constants';
 import { useGetTotalWorkoutCount } from '@/lib/react-query/useTotalWorkoutCount';
 import { accessTokenAtom } from '@/stores/atoms/accessTokenAtom';
 import { modalTypeAtom } from '@/stores/atoms/modalTypeAtom';
@@ -14,20 +15,29 @@ export const TotalCountByAllWorkoutsChart = () => {
     return null;
   }
 
-  const { totalCountByWorkout: totalCountByWorkoutData } = data;
+  const { totalCountByWorkout: totalCountByWorkoutStepData } = data;
 
-  const mostCommonWorkoutName = totalCountByWorkoutData.reduce((prevWorkoutData, workoutData) => {
-    return prevWorkoutData.totalCount >= workoutData.totalCount ? prevWorkoutData : workoutData;
-  }).workout;
+  const totalCountByWorkoutNameData = totalCountByWorkoutStepData.map(({ step, totalCount }) => {
+    return {
+      workoutName: WORKOUT_NAME[step],
+      totalCount,
+    };
+  });
+
+  const mostCommonWorkoutName = totalCountByWorkoutNameData.reduce(
+    (prevWorkoutData, workoutData) => {
+      return prevWorkoutData.totalCount >= workoutData.totalCount ? prevWorkoutData : workoutData;
+    },
+  ).workoutName;
 
   return (
     <section className="flex w-full flex-col items-center bg-gray-6 py-4">
       <p className="text-center text-xs">
         <span className="text-primary">{mostCommonWorkoutName}</span>을 가장 많이 하셨어요!
       </p>
-      <RadarChart outerRadius={70} width={350} height={230} data={totalCountByWorkoutData}>
+      <RadarChart outerRadius={70} width={350} height={230} data={totalCountByWorkoutNameData}>
         <PolarGrid />
-        <PolarAngleAxis dataKey="workout" style={{ fontSize: '14px', color: '#505050' }} />
+        <PolarAngleAxis dataKey="workoutName" style={{ fontSize: '14px', color: '#505050' }} />
         <PolarRadiusAxis angle={30} style={{ fontSize: '12px' }} />
         <Radar
           name="봉철이"

--- a/src/stores/atoms/workoutDataAtom.ts
+++ b/src/stores/atoms/workoutDataAtom.ts
@@ -1,10 +1,9 @@
 import { atom } from 'jotai';
 
+import { StepIdForWorkout } from '@/types/workout';
 import { getImpossiblePullUps } from '@/utils/getImpossiblePullUps';
 
-export type WorkoutId = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
-
-const initialWorkoutData = new Set<WorkoutId>([1]);
+const initialWorkoutData = new Set<StepIdForWorkout>([1]);
 
 export type WorkoutData = typeof initialWorkoutData;
 

--- a/src/types/workout.ts
+++ b/src/types/workout.ts
@@ -1,0 +1,1 @@
+export type StepIdForWorkout = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;


### PR DESCRIPTION
## Issues
- Issue number #121 

## Tasks Done 
- Summary API 명세 수정 반영
  - [x] 8가지 풀업 운동별 총 운동 횟수 데이터의 **workout**을 **step**으로 변경
  - [x] 월별 풀업 운동 횟수 데이터를 **workoutName** 키와 해당 데이터를 가진 객체에서 **step**, **data** 속성을 가진 객체들의 배열로 변경
- 컴포넌트에 반영
  - [x] `TotalCountByAllWorkoutsChart` 컴포넌트에 변경된 8가지 풀업 운동별 총 운동 횟수 데이터를 반영함
  - [x] `MonthlyTotalCountByEachWorkoutChart` 컴포넌트에 변경된 월별 풀업 운동 횟수 데이터를 반영함

<br>

## Description
### Summary API 명세 수정 반영

- 배경 : 백엔드님이 서버 데이터에 변경의 여지가 있는 **workoutName** 대신에 불변의 **stepId**를 사용하는 것이 유지 보수 측면에서 좋을 것 같다고 제안해주셔서 Summary API 명세를 수정했습니다.
- 변경 사항
  - 8가지 풀업 운동별 총 운동 횟수 데이터(`TotalWorkoutCount`)의 **workout** 속성을 **step** 속성으로 변경했습니다.
  - 월별 풀업 운동 횟수 데이터 키 이름을 **data** 대신에 더 구체적으로 **workoutCountPerMonth**으로 변경했습니다.
  - 월별 풀업 운동 횟수 데이터 값(`MonthWorkoutCount`)을 **workoutName** 키와 **month**와 **totalCount** 속성을 가진 객체 배열 값으로 구성된 객체 대신에, **step** 키와 **stepId** 값 그리고 **data** 키와 **month**와 **totalCount** 속성을 가진 객체 배열 값을 가진 객체 배열로 변경했습니다.

```ts
// TotalWorkoutCount/data.ts
// before
type WorkoutNames = 'Hanging' | 'Jumping Pull-up' | 'Band Pull-up' | 'Chin-up' | 'Pull-up' | 'Chest to Bar' | 'Archer Pull-up' | 'Muscle up';
export type TotalWorkoutCount = {
  totalCountByWorkout: {
    workout: WorkoutNames;
    totalCount: number;
  }[];
};

// after
type StepIdForWorkout = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
export type TotalWorkoutCount = {
  totalCountByWorkout: {
    step: StepIdForWokrkout;
    totalCount: number;
  }[];
};
```

```ts
// MonthWorkoutCount/data.ts
// before
type WorkoutNames = 'Hanging' | 'Jumping Pull-up' | 'Band Pull-up' | 'Chin-up' | 'Pull-up' | 'Chest to Bar' | 'Archer Pull-up' | 'Muscle up';
export type MonthWorkoutCount = {
  data: {
    [K in WorkoutNames]: {
      month: keyof typeof MONTH_NAME_IN_KOREAN;
      totalCount: number;
    }[];
  };
};

// after
type StepIdForWorkout = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
export type MonthWorkoutCount = {
  workoutCountPerMonth: {
    step: StepIdForWorkout;
    data: {
      month: keyof typeof MONTH_NAME_IN_KOREAN;
      totalCount: number;
    }[];
  }[];
};
```

<br>

### TotalCountByAllWorkoutsChart 컴포넌트에 변경된 데이터 적용
-  8가지 풀업 운동별 총 운동 횟수 데이터에서 **step** 속성을 **workoutName** 속성으로 변경했습니다.
  - `WORKOUT_NAME` 상수를 통해 해당 **step**에 대한 **workoutName** 값을 나타냈습니다.
  - 그래프의 x축을 **workout** 대신에 더 구체적으로 **workoutName**으로 변경했습니다.

<br>

### MonthlyTotalCountByEachWorkoutChart 컴포넌트에 변경된 데이터 적용
- **workoutName** 상태를 **stepId** 상태로 변경했습니다.
-  `WORKOUT_NAME_COLOR` 객체를 통해 해당 **stepId** 상태에 대한 **workoutName**과 **color**  변수를 선언하여 사용했습니다.
- find 메서드를 통해 해당 **stepId** 상태에 대한 월별 풀업 운동 횟수 데이터를 **workoutCountPerMonthData** 변수에 저장하여 사용했습니다.
- `MonthDropdown` 컴포넌트의 버튼 클릭 시, 클릭된 버튼의 **id** 속성값을 **stepId** 상태에 저장하여 사용했습니다.
- 더 이상 필요하지 않은 `COLOR_BY_WORKOUT` 상수를 삭제했습니다.

<br>

### 타입 리팩터링
- 자주 사용하는 `1 | 2 | 3 | 4 | 5 | 6 | 7 | 8` 타입을 **StepIdForWorkout** 타입으로 선언하여 재활용했습니다.
  - `types/plan` 파일에 동일한 **PullUpSteps** 타입이 있으나 `types/plan` 경로가 애매하다고 생각하여 `types/workout` 타일을 만들어서 **StepIdForWorkout** 타입을 선언했습니다.
  - 추후에 논의 후 한 타입으로 합쳐도 좋을 것 같습니다.
