### PR TITLE
Fix/#125 nickname

### DIFF
--- a/src/apis/user/validateNickname.ts
+++ b/src/apis/user/validateNickname.ts
@@ -29,6 +29,6 @@ export const validateNickname = async (
 
     return data.code === SUCCESS_RESPONSE_CODE;
   } catch (error) {
-    throw new Error();
+    return false;
   }
 };

--- a/src/components/inputs/DuplicationCheckInput/index.tsx
+++ b/src/components/inputs/DuplicationCheckInput/index.tsx
@@ -62,13 +62,13 @@ export const DuplicationCheckInput = ({
     }
 
     try {
-      const isInputNotDuplicated = await validationFunction(
+      const isInputValid = await validationFunction(
         inputValue,
         accessToken,
         setAccessToken,
         setModalType,
       );
-      if (isInputNotDuplicated) {
+      if (isInputValid) {
         setInputStatus(VALID_INPUT.status);
         setValidInputValue(inputValue);
       } else {

--- a/src/mocks/users/handler.ts
+++ b/src/mocks/users/handler.ts
@@ -35,7 +35,7 @@ const getNicknameValidation = async (
   const nickname = params.get('nickname');
   const isNicknameDuplicated = nickname ? USER_NICKNAMES.includes(nickname) : false;
   if (isNicknameDuplicated) {
-    return res(ctx.status(200), ctx.json({ code: 'U03', message: '이미 존재하는 닉네임입니다' }));
+    return res(ctx.status(400), ctx.json({ code: 'U03', message: '이미 존재하는 닉네임입니다' }));
   }
 
   return res(ctx.status(200), ctx.json({ code: 'U04', message: '사용 가능한 닉네임입니다.' }));

--- a/src/pages/Root/index.tsx
+++ b/src/pages/Root/index.tsx
@@ -1,6 +1,6 @@
 import { useAtom, useAtomValue } from 'jotai';
 import { useEffect } from 'react';
-import { Outlet } from 'react-router-dom';
+import { Outlet, useNavigate } from 'react-router-dom';
 
 import { BottomNavigationBar } from '@/components/BottomNavigationBar';
 import { ScrollTopButton } from '@/components/buttons/ScrollTopButton';
@@ -8,15 +8,19 @@ import { Header } from '@/components/Header';
 import { AccountHijackingModal } from '@/components/modals/AccountHijackingModal';
 import { LoginExpirationModal } from '@/components/modals/LoginExpirationModal';
 import { LogoutModal } from '@/components/modals/LogoutModal';
+import { ROUTE_PATH } from '@/constants';
 import { accessTokenAtom } from '@/stores/atoms/accessTokenAtom';
 import { loginStateAtom } from '@/stores/atoms/loginStateAtom';
 import { modalTypeAtom } from '@/stores/atoms/modalTypeAtom';
+import { userDataAtom, type UserData } from '@/stores/atoms/userDataAtom';
 import { initializeAccessToken } from '@/utils/initializeAccessToken';
 
 export const Root = () => {
   const [accessToken, setAccessToken] = useAtom(accessTokenAtom);
   const loginState = useAtomValue(loginStateAtom) as boolean;
   const [modalType, setModalType] = useAtom(modalTypeAtom);
+  const userData = useAtomValue(userDataAtom) as UserData;
+  const navigate = useNavigate();
   const isProductionMode = import.meta.env.PROD;
 
   useEffect(() => {
@@ -24,6 +28,12 @@ export const Root = () => {
       initializeAccessToken(setAccessToken, setModalType);
     }
   }, [isProductionMode, loginState, accessToken, setAccessToken, setModalType]);
+
+  useEffect(() => {
+    if (userData && !userData.nickname) {
+      navigate(ROUTE_PATH.setup.setNickname);
+    }
+  }, [userData, navigate]);
 
   return (
     <div className="flex h-screen w-screen flex-row items-center justify-center">


### PR DESCRIPTION
## Issues
- Issue number #125 

## Tasks Done 
- [x] `validateNickname`의 에러 처리 로직 수정
- [x] 닉네임이 null인 경우, 닉네임 설정 페이지로 돌아가도록 로직 수정

## Description
### 닉네임 중복 검사 시 닉네임이 중복된 결과가 화면에 나타나지 않는 문제
- 문제 : 닉네임 중복 검사 API 요청했을 때, 이미 존재하는 닉네임인 경우에 대해 문구가 나타나지 않았습니다.
- 원인 : 이전에는 닉네임 중복 여부와 관계 없이 Response의 HTTP Status는 **200**이고, code로 닉네임 중복 여부를 나타냈습니다. 하지만 지금은 이미 존재하는 닉네임인 경우 Resonse의 HTTP Status가 **400**이기 때문에, catch 구문에서 에러 처리를 해줘야 합니다.
- 해결 : `validateNickname` 함수의 catch 문에서 **false**를 반환함으로써 문제를 해결했습니다.
  - `validateNickname` 함수의 반환값을 저장한 변수 `isInputValid`를 통해 닉네임 중복 결과를 화면에 보여줍니다.
  - `validateNickname` 함수 결과에 대한 경우의 수는 유효함/유효하지 않음 두 가지 경우만 존재하므로, 이미 존재하는 닉네임의 경우 유효한 닉네임이 아니기 때문에 **false**를 반환해줍니다.

<br>

### 닉네임이 null인 경우에 대한 예외 처리
- 문제 : 닉네임 설정 화면에서 url을 통해 다른 페이지로 강제로 넘어갈 경우 에러가 발생합니다.
- 원인 : 닉네임을 설정하지 않은 상태에서 다른 페이지로 넘어갔으므로, 닉네임이 **null**이기 때문에 닉네임의 length를 읽을 수 없습니다.
- 해결 : `Root` 페이지에서 로그인을 해서 유저정보가 있지만, 닉네임이 설정되지 않은 경우 닉네임 설정 페이지로 넘어가도록 **useEffect**를 추가해줍니다.

## Visuals
### 닉네임 중복 검사 관련 문제
#### 닉네임 중복 검사 시 닉네임이 중복된 결과가 나타나지 않는 화면
![validateNicknameResultNotAppear](https://github.com/Pullanner/pullanner-web/assets/70058081/e61f7d74-02a9-45d9-8d39-97e847247f20)
#### 닉네임이 중복된 결과도 보이도록 해결한 화면
![modifiedValidateNickname](https://github.com/Pullanner/pullanner-web/assets/70058081/0a86c06e-348d-4495-b61c-52888570279a)

<br>

### 닉네임 null 예외 처리 관련 문제
#### 닉네임이 null이 되서 에러가 생긴 하면
![nullNicknameError](https://github.com/Pullanner/pullanner-web/assets/70058081/a8ef3717-f3a5-4147-8f77-065224ac1470)
#### 닉네임이 null인 경우 닉네임 설정 페이지로 이동하는 화면
![preventNullNickname](https://github.com/Pullanner/pullanner-web/assets/70058081/6e593f09-023f-4c84-9ca5-e0d82f316e7d)