### PR TITLE
Refactor/#105 new plan

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -6,3 +6,4 @@ export * from './roadmapData';
 export * from './plan';
 export * from './summary';
 export * from './date';
+export * from './message';

--- a/src/constants/message.ts
+++ b/src/constants/message.ts
@@ -1,4 +1,15 @@
+import { SuccessIcon } from '@/icons/SuccessIcon';
 import { WarningIcon } from '@/icons/WarningIcon';
+
+export const SUCCESS_MESSAGE_OPTION = {
+  type: 'success' as const,
+  content: '',
+  duration: 5,
+  style: {
+    marginTop: '75vh',
+  },
+  icon: SuccessIcon(),
+};
 
 export const WARNING_MESSAGE_OPTION = {
   type: 'warning' as const,

--- a/src/constants/message.ts
+++ b/src/constants/message.ts
@@ -1,0 +1,11 @@
+import { WarningIcon } from '@/icons/WarningIcon';
+
+export const WARNING_MESSAGE_OPTION = {
+  type: 'warning' as const,
+  content: '',
+  duration: 5,
+  style: {
+    marginTop: '75vh',
+  },
+  icon: WarningIcon(),
+};

--- a/src/constants/plan.ts
+++ b/src/constants/plan.ts
@@ -11,7 +11,7 @@ export const PLAN_TYPE_KR = {
 } as const;
 
 export const PLAN_MESSAGE = {
-  pastDate: '오늘 이전 날짜에는 플랜을 생성할 수 없어요.',
+  afterDate: '오늘 이후 날짜부터 플랜을 생성할 수 있습니다.',
   pastTime: '현재 시각 이전으로는 플랜을 생성할 수 없어요.',
   allMaster: `모든 풀업 운동이 가능해서 마스터 할 동작이 없어요! 대신, [${PLAN_TYPE_KR.strength}]을 만들 수 있어요.`,
 } as const;

--- a/src/constants/plan.ts
+++ b/src/constants/plan.ts
@@ -3,16 +3,17 @@ export const PLAN_TYPE = {
   master: 'master',
 } as const;
 
-export const PLAN_MESSAGE = {
-  pastDate: '오늘 이전 날짜에는 플랜을 생성할 수 없어요.',
-  pastTime: '현재 시각 이전으로는 플랜을 생성할 수 없어요.',
-} as const;
-
 export const PLAN_TIME_FORMAT = 'HH:mm';
 
 export const PLAN_TYPE_KR = {
   strength: '💪 근력 키우기 플랜',
   master: '🏆 동작 마스터 플랜',
+} as const;
+
+export const PLAN_MESSAGE = {
+  pastDate: '오늘 이전 날짜에는 플랜을 생성할 수 없어요.',
+  pastTime: '현재 시각 이전으로는 플랜을 생성할 수 없어요.',
+  allMaster: `모든 풀업 운동이 가능해서 마스터 할 동작이 없어요! 대신, [${PLAN_TYPE_KR.strength}]을 만들 수 있어요.`,
 } as const;
 
 export const NEW_PLAN_DESCRIPTION = {

--- a/src/constants/plan.ts
+++ b/src/constants/plan.ts
@@ -19,3 +19,17 @@ export const NEW_PLAN_DESCRIPTION = {
   strength: `[${PLAN_TYPE_KR.strength}]에서는 가능한 풀업 운동을 계획해서 연습할 수 있어요. 풀업으로 열심히 근력을 키워볼까요?`,
   master: `[${PLAN_TYPE_KR.master}]에서는 아직 불가능한 풀업 운동을 계획해서 연습할 수 있어요. 모든 동작을 마스터하는 그날까지!`,
 } as const;
+
+export const NEW_PLAN_TITLE = {
+  planName: '😎 이번 풀업 계획의 이름은 뭘로 할까요?',
+  workoutTime: '⏰ 풀업 운동을 언제 할까요?',
+  workoutTable: '💪 어떤 풀업 운동을 해볼까요?',
+};
+
+export const WORKOUT_TIME_DESCRIPTION =
+  '플랜 날짜가 오늘이면, 현재 시각보다 이후의 시각으로 설정해주세요.';
+
+export const WORKOUT_TABLE_DESCRIPTION = {
+  manual: ' 연습할 풀업 운동을 선택 후, 횟수(Count)와 세트(Set)를 입력해주세요.',
+  hanging: 'Hanging은 횟수 대신 초(Second) 단위로 입력해주세요.',
+} as const;

--- a/src/pages/DeleteAccount/AuthenticationCodeInput.tsx
+++ b/src/pages/DeleteAccount/AuthenticationCodeInput.tsx
@@ -1,5 +1,5 @@
-import { useAtom, useAtomValue, useSetAtom } from 'jotai';
-import { useState, forwardRef } from 'react';
+import { useAtom, useSetAtom } from 'jotai';
+import { useState, forwardRef, useEffect } from 'react';
 
 import { deleteAccountWithAuthenticationCode } from '@/apis/user';
 import { accessTokenAtom } from '@/stores/atoms/accessTokenAtom';
@@ -23,7 +23,7 @@ export const AuthenticationCodeInput = forwardRef<HTMLInputElement>(
     const [isDeleteAccountButtonActive, setDeleteAccountButtonActive] = useState(false);
     const [isDeleteRequestFailed, setShowInvalidAuthenticationCodeDescription] = useState(false);
     const [accessToken, setAccessToken] = useAtom(accessTokenAtom);
-    const isTimerActive = useAtomValue(isTimerActiveAtom);
+    const [isTimerActive, setTimerActive] = useAtom(isTimerActiveAtom);
     const setModalType = useSetAtom(modalTypeAtom);
 
     const deleteAccountButtonState = isDeleteAccountButtonActive
@@ -56,6 +56,12 @@ export const AuthenticationCodeInput = forwardRef<HTMLInputElement>(
 
       setDeleteAccountButtonActive(inputNumberValue.length === MAX_INPUT_LENGTH);
     };
+
+    useEffect(() => {
+      return () => {
+        setTimerActive(false);
+      };
+    }, []);
 
     return (
       <div className="pt-6">

--- a/src/pages/DeleteAccount/constants.ts
+++ b/src/pages/DeleteAccount/constants.ts
@@ -15,3 +15,5 @@ export const VALIDATE_CODE_BUTTON_STYLE = {
 export const LIMIT_TIME = 3 * 60 * 1000;
 
 export const DECADE = 10;
+
+export const AUTHORIZATION_CODE_SENT_SUCCESSFULLY = '이메일로 인증 코드가 발송되었습니다.';

--- a/src/pages/DeleteAccount/index.tsx
+++ b/src/pages/DeleteAccount/index.tsx
@@ -5,12 +5,13 @@ import { useRef } from 'react';
 import { sendAuthenticationCode } from '@/apis/user';
 import { SaveButton } from '@/components/buttons/SaveButton';
 import { DeleteAccountSuccessModal } from '@/components/modals/DeleteAccountSuccessModal';
-import { SuccessIcon } from '@/icons/SuccessIcon';
+import { SUCCESS_MESSAGE_OPTION } from '@/constants';
 import { accessTokenAtom } from '@/stores/atoms/accessTokenAtom';
 import { isTimerActiveAtom } from '@/stores/atoms/isTimerActiveAtom';
 import { modalTypeAtom } from '@/stores/atoms/modalTypeAtom';
 
 import { AuthenticationCodeInput } from './AuthenticationCodeInput';
+import { AUTHORIZATION_CODE_SENT_SUCCESSFULLY } from './constants';
 import { DeleteAccountDescription } from './DeleteAccountDescription';
 
 export const DeleteAccount = () => {
@@ -31,13 +32,8 @@ export const DeleteAccount = () => {
     const isSuccess = await sendAuthenticationCode(accessToken, setAccessToken, setModalType);
     if (isSuccess) {
       messageApi.open({
-        type: 'success',
-        content: '이메일로 인증 코드가 발송되었습니다.',
-        duration: 2,
-        style: {
-          marginTop: '75vh',
-        },
-        icon: SuccessIcon(),
+        ...SUCCESS_MESSAGE_OPTION,
+        content: AUTHORIZATION_CODE_SENT_SUCCESSFULLY,
       });
     }
   };

--- a/src/pages/NewPlan/PlanNameSection.tsx
+++ b/src/pages/NewPlan/PlanNameSection.tsx
@@ -1,5 +1,7 @@
 import { Input } from 'antd';
 
+import { NEW_PLAN_TITLE } from '@/constants';
+
 import type { ChangeEvent } from 'react';
 
 type PlanNameSectionProps = {
@@ -11,7 +13,7 @@ export const PlanNameSection = ({ planName, handlePlanInputChange }: PlanNameSec
   return (
     <section>
       <div>
-        <p className="py-2">😎 이번 풀업 계획의 이름은 뭘로 할까요?</p>
+        <p className="py-2">{NEW_PLAN_TITLE.planName}</p>
       </div>
       <Input
         status={planName.length ? '' : 'error'}

--- a/src/pages/NewPlan/PlanNameSection.tsx
+++ b/src/pages/NewPlan/PlanNameSection.tsx
@@ -1,0 +1,27 @@
+import { Input } from 'antd';
+
+import type { ChangeEvent } from 'react';
+
+type PlanNameSectionProps = {
+  planName: string;
+  handlePlanInputChange: ({ target: { value } }: ChangeEvent<HTMLInputElement>) => void;
+};
+
+export const PlanNameSection = ({ planName, handlePlanInputChange }: PlanNameSectionProps) => {
+  return (
+    <section>
+      <div>
+        <p className="py-2">😎 이번 풀업 계획의 이름은 뭘로 할까요?</p>
+      </div>
+      <Input
+        status={planName.length ? '' : 'error'}
+        showCount
+        maxLength={20}
+        allowClear
+        value={planName}
+        onChange={handlePlanInputChange}
+        placeholder="1자 이상 20자 이하로 입력해주세요"
+      />
+    </section>
+  );
+};

--- a/src/pages/NewPlan/WorkoutTableSection.tsx
+++ b/src/pages/NewPlan/WorkoutTableSection.tsx
@@ -3,7 +3,7 @@ import { useAtom } from 'jotai';
 import { SelectablePullUpCard } from '@/components/cards/SelectablePullupCard';
 import { WorkoutTable } from '@/components/WorkoutTable';
 import { usePlanComplete } from '@/components/WorkoutTable/hooks/usePlanComplete';
-import { PLAN_TYPE, ROADMAP_DATA } from '@/constants';
+import { NEW_PLAN_TITLE, PLAN_TYPE, ROADMAP_DATA, WORKOUT_TABLE_DESCRIPTION } from '@/constants';
 import { workoutPlanAtom } from '@/stores/atoms/workoutPlanAtom';
 import type { PlanType, PullUpSteps } from '@/types/plan';
 import { StepIdForWorkout } from '@/types/workout';
@@ -40,12 +40,10 @@ export const WorkoutTableSection = ({ planType, pullUpList }: WorkoutTableSectio
   return (
     <section>
       <div>
-        <p className="py-2">💪 어떤 풀업 운동을 해볼까요?</p>
-        <p className="mb-2 text-sm ">
-          연습할 풀업 운동을 선택 후, 횟수(Count)와 세트(Set)를 입력해주세요.
-        </p>
+        <p className="py-2">{NEW_PLAN_TITLE.workoutTable}</p>
+        <p className="mb-2 text-sm ">{WORKOUT_TABLE_DESCRIPTION.manual}</p>
         {planType === PLAN_TYPE.strength && (
-          <p className="mb-2 text-sm">Hanging은 횟수 대신 초(Second) 단위로 입력해주세요.</p>
+          <p className="mb-2 text-sm">{WORKOUT_TABLE_DESCRIPTION.hanging}</p>
         )}
       </div>
       <div className="flex flex-wrap justify-center gap-3">

--- a/src/pages/NewPlan/WorkoutTableSection.tsx
+++ b/src/pages/NewPlan/WorkoutTableSection.tsx
@@ -1,0 +1,80 @@
+import { useAtom } from 'jotai';
+
+import { SelectablePullUpCard } from '@/components/cards/SelectablePullupCard';
+import { WorkoutTable } from '@/components/WorkoutTable';
+import { usePlanComplete } from '@/components/WorkoutTable/hooks/usePlanComplete';
+import { PLAN_TYPE, ROADMAP_DATA } from '@/constants';
+import { workoutPlanAtom } from '@/stores/atoms/workoutPlanAtom';
+import type { PlanType, PullUpSteps } from '@/types/plan';
+import { StepIdForWorkout } from '@/types/workout';
+
+type WorkoutTableSectionProps = {
+  planType: PlanType;
+  pullUpList: StepIdForWorkout[];
+};
+
+export const WorkoutTableSection = ({ planType, pullUpList }: WorkoutTableSectionProps) => {
+  const [workoutPlan, setWorkoutPlan] = useAtom(workoutPlanAtom);
+  const { checkPlanComplete } = usePlanComplete();
+
+  const addWorkoutRow = (step: PullUpSteps) => {
+    setWorkoutPlan((prev) => {
+      const updatedWorkoutPlan = [...prev, { step, count: 0, set: 0, done: false }];
+      checkPlanComplete(updatedWorkoutPlan);
+
+      return updatedWorkoutPlan;
+    });
+  };
+
+  const deleteWorkoutRow = (step: PullUpSteps) => {
+    setWorkoutPlan((prev) => {
+      const updatedWorkoutPlan = prev.filter((w) => {
+        return w.step !== step;
+      });
+      checkPlanComplete(updatedWorkoutPlan);
+
+      return updatedWorkoutPlan;
+    });
+  };
+
+  return (
+    <section>
+      <div>
+        <p className="py-2">💪 어떤 풀업 운동을 해볼까요?</p>
+        <p className="mb-2 text-sm ">
+          연습할 풀업 운동을 선택 후, 횟수(Count)와 세트(Set)를 입력해주세요.
+        </p>
+        {planType === PLAN_TYPE.strength && (
+          <p className="mb-2 text-sm">Hanging은 횟수 대신 초(Second) 단위로 입력해주세요.</p>
+        )}
+      </div>
+      <div className="flex flex-wrap justify-center gap-3">
+        {pullUpList.map((workoutId) => {
+          const workoutData = ROADMAP_DATA.find((v) => {
+            return v.id === workoutId;
+          });
+
+          if (!workoutData) {
+            return null;
+          }
+
+          const { id, name, imageSrc, color } = workoutData;
+
+          return (
+            <SelectablePullUpCard
+              id={id}
+              name={name}
+              width="100px"
+              height=""
+              imageSrc={imageSrc}
+              color={color}
+              onAdd={addWorkoutRow}
+              onDelete={deleteWorkoutRow}
+            />
+          );
+        })}
+      </div>
+      <div className="py-5">{workoutPlan.length > 0 && <WorkoutTable />}</div>
+    </section>
+  );
+};

--- a/src/pages/NewPlan/WorkoutTimeSection.tsx
+++ b/src/pages/NewPlan/WorkoutTimeSection.tsx
@@ -1,6 +1,6 @@
 import { TimePicker } from 'antd';
 
-import { PLAN_TIME_FORMAT } from '@/constants';
+import { NEW_PLAN_TITLE, PLAN_TIME_FORMAT, WORKOUT_TIME_DESCRIPTION } from '@/constants';
 
 import type { Dayjs } from 'dayjs';
 
@@ -16,10 +16,8 @@ export const WorkoutTimeSection = ({
   return (
     <section>
       <div>
-        <p className="py-2">⏰ 풀업 운동을 언제 할까요?</p>
-        <p className="mb-2 text-sm">
-          플랜 날짜가 오늘이면, 현재 시각보다 이후의 시각으로 설정해주세요.
-        </p>
+        <p className="py-2">{NEW_PLAN_TITLE.workoutTime}</p>
+        <p className="mb-2 text-sm">{WORKOUT_TIME_DESCRIPTION}</p>
       </div>
       <TimePicker
         status={planDateTime ? '' : 'error'}

--- a/src/pages/NewPlan/WorkoutTimeSection.tsx
+++ b/src/pages/NewPlan/WorkoutTimeSection.tsx
@@ -1,0 +1,32 @@
+import { TimePicker } from 'antd';
+
+import { PLAN_TIME_FORMAT } from '@/constants';
+
+import type { Dayjs } from 'dayjs';
+
+type WorkoutTableSectionProps = {
+  planDateTime: string;
+  handleTimePickerChange: (_: Dayjs | null, selectedTime: string) => void;
+};
+
+export const WorkoutTimeSection = ({
+  planDateTime,
+  handleTimePickerChange,
+}: WorkoutTableSectionProps) => {
+  return (
+    <section>
+      <div>
+        <p className="py-2">⏰ 풀업 운동을 언제 할까요?</p>
+        <p className="mb-2 text-sm">
+          플랜 날짜가 오늘이면, 현재 시각보다 이후의 시각으로 설정해주세요.
+        </p>
+      </div>
+      <TimePicker
+        status={planDateTime ? '' : 'error'}
+        format={PLAN_TIME_FORMAT}
+        onChange={handleTimePickerChange}
+        placeholder="12:00"
+      />
+    </section>
+  );
+};

--- a/src/pages/NewPlan/index.tsx
+++ b/src/pages/NewPlan/index.tsx
@@ -1,29 +1,22 @@
-import { TimePicker, message, Input } from 'antd';
+import { message } from 'antd';
 import dayjs from 'dayjs';
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { ChangeEvent, useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import { SaveButton } from '@/components/buttons/SaveButton';
-import { SelectablePullUpCard } from '@/components/cards/SelectablePullupCard';
-import { WorkoutTable } from '@/components/WorkoutTable';
-import { usePlanComplete } from '@/components/WorkoutTable/hooks/usePlanComplete';
-import {
-  NEW_PLAN_DESCRIPTION,
-  PLAN_MESSAGE,
-  PLAN_TIME_FORMAT,
-  PLAN_TYPE,
-  ROADMAP_DATA,
-  ROUTE_PATH,
-} from '@/constants';
+import { NEW_PLAN_DESCRIPTION, PLAN_MESSAGE, PLAN_TYPE, ROUTE_PATH } from '@/constants';
 import { WarningIcon } from '@/icons/WarningIcon';
 import { usePostPlan } from '@/lib/react-query/usePlans';
 import { accessTokenAtom } from '@/stores/atoms/accessTokenAtom';
 import { modalTypeAtom } from '@/stores/atoms/modalTypeAtom';
 import { impossiblePullUpAtom, possiblePullUpAtom } from '@/stores/atoms/workoutDataAtom';
 import { planCompleteAtom, workoutPlanAtom } from '@/stores/atoms/workoutPlanAtom';
-import { PullUpSteps } from '@/types/plan';
 import { checkPastDateTime, convertToUTCDate } from '@/utils/date';
+
+import { PlanNameSection } from './PlanNameSection';
+import { WorkoutTableSection } from './WorkoutTableSection';
+import { WorkoutTimeSection } from './WorkoutTimeSection';
 
 import type { Dayjs } from 'dayjs';
 
@@ -59,7 +52,6 @@ export const NewPlan = () => {
   const [workoutPlan, setWorkoutPlan] = useAtom(workoutPlanAtom);
   const [messageApi, contextHolder] = message.useMessage();
   const [isPlanComplete, setIsPlanComplete] = useAtom(planCompleteAtom);
-  const { checkPlanComplete } = usePlanComplete();
   const [accessToken, setAccessToken] = useAtom(accessTokenAtom);
   const setModalType = useSetAtom(modalTypeAtom);
   const { mutate: postPlan } = usePostPlan(accessToken, setAccessToken, setModalType);
@@ -109,26 +101,6 @@ export const NewPlan = () => {
     }
   };
 
-  const addWorkoutRow = (step: PullUpSteps) => {
-    setWorkoutPlan((prev) => {
-      const updatedWorkoutPlan = [...prev, { step, count: 0, set: 0, done: false }];
-      checkPlanComplete(updatedWorkoutPlan);
-
-      return updatedWorkoutPlan;
-    });
-  };
-
-  const deleteWorkoutRow = (step: PullUpSteps) => {
-    setWorkoutPlan((prev) => {
-      const updatedWorkoutPlan = prev.filter((w) => {
-        return w.step !== step;
-      });
-      checkPlanComplete(updatedWorkoutPlan);
-
-      return updatedWorkoutPlan;
-    });
-  };
-
   return (
     <div>
       <img src={`/assets/images/banner/${planType}.jpg`} alt={planType} />
@@ -146,72 +118,12 @@ export const NewPlan = () => {
       </div>
       <div className="p-5">
         <form className="flex flex-col gap-5">
-          <div>
-            <div>
-              <p className="py-2">😎 이번 풀업 계획의 이름은 뭘로 할까요?</p>
-            </div>
-            <Input
-              status={planName.length ? '' : 'error'}
-              showCount
-              maxLength={20}
-              allowClear
-              value={planName}
-              onChange={handlePlanInputChange}
-              placeholder="1자 이상 20자 이하로 입력해주세요"
-            />
-          </div>
-          <div>
-            <div>
-              <p className="py-2">⏰ 풀업 운동을 언제 할까요?</p>
-              <p className="mb-2 text-sm">
-                플랜 날짜가 오늘이면, 현재 시각보다 이후의 시각으로 설정해주세요.
-              </p>
-            </div>
-            <TimePicker
-              status={planDateTime ? '' : 'error'}
-              format={PLAN_TIME_FORMAT}
-              onChange={handleTimePickerChange}
-              placeholder="12:00"
-            />
-          </div>
-          <div>
-            <div>
-              <p className="py-2">💪 어떤 풀업 운동을 해볼까요?</p>
-              <p className="mb-2 text-sm ">
-                연습할 풀업 운동을 선택 후, 횟수(Count)와 세트(Set)를 입력해주세요.
-              </p>
-              {planType === PLAN_TYPE.strength && (
-                <p className="mb-2 text-sm">Hanging은 횟수 대신 초(Second) 단위로 입력해주세요.</p>
-              )}
-            </div>
-            <div className="flex flex-wrap justify-center gap-3">
-              {pullUpList.map((workoutId) => {
-                const workoutData = ROADMAP_DATA.find((v) => {
-                  return v.id === workoutId;
-                });
-
-                if (!workoutData) {
-                  return null;
-                }
-
-                const { id, name, imageSrc, color } = workoutData;
-
-                return (
-                  <SelectablePullUpCard
-                    id={id}
-                    name={name}
-                    width="100px"
-                    height=""
-                    imageSrc={imageSrc}
-                    color={color}
-                    onAdd={addWorkoutRow}
-                    onDelete={deleteWorkoutRow}
-                  />
-                );
-              })}
-            </div>
-            <div className="py-5">{workoutPlan.length > 0 && <WorkoutTable />}</div>
-          </div>
+          <PlanNameSection planName={planName} handlePlanInputChange={handlePlanInputChange} />
+          <WorkoutTimeSection
+            planDateTime={planDateTime}
+            handleTimePickerChange={handleTimePickerChange}
+          />
+          <WorkoutTableSection planType={planType} pullUpList={pullUpList} />
           <SaveButton
             isActive={!!(planName && planDateTime) && isPlanComplete}
             width="100%"

--- a/src/pages/NewPlan/index.tsx
+++ b/src/pages/NewPlan/index.tsx
@@ -5,8 +5,13 @@ import { ChangeEvent, useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import { SaveButton } from '@/components/buttons/SaveButton';
-import { NEW_PLAN_DESCRIPTION, PLAN_MESSAGE, PLAN_TYPE, ROUTE_PATH } from '@/constants';
-import { WarningIcon } from '@/icons/WarningIcon';
+import {
+  NEW_PLAN_DESCRIPTION,
+  PLAN_MESSAGE,
+  PLAN_TYPE,
+  ROUTE_PATH,
+  WARNING_MESSAGE_OPTION,
+} from '@/constants';
 import { usePostPlan } from '@/lib/react-query/usePlans';
 import { accessTokenAtom } from '@/stores/atoms/accessTokenAtom';
 import { modalTypeAtom } from '@/stores/atoms/modalTypeAtom';
@@ -19,16 +24,6 @@ import { WorkoutTableSection } from './WorkoutTableSection';
 import { WorkoutTimeSection } from './WorkoutTimeSection';
 
 import type { Dayjs } from 'dayjs';
-
-const PAST_TIME_PLAN_MESSAGE_OPTION = {
-  type: 'warning' as const,
-  content: PLAN_MESSAGE.pastTime,
-  duration: 2,
-  style: {
-    marginTop: '75vh',
-  },
-  icon: WarningIcon(),
-};
 
 type PlanType = keyof typeof NEW_PLAN_DESCRIPTION;
 
@@ -96,7 +91,7 @@ export const NewPlan = () => {
     setPlanDateTime(planDateTimeUtc);
     const isPast = checkPastDateTime(planDate, selectedTime);
     if (isPast) {
-      messageApi.open(PAST_TIME_PLAN_MESSAGE_OPTION);
+      messageApi.open({ ...WARNING_MESSAGE_OPTION, content: PLAN_MESSAGE.pastTime });
       setPlanDateTime('');
     }
   };

--- a/src/pages/Plan/PlanButtons/index.tsx
+++ b/src/pages/Plan/PlanButtons/index.tsx
@@ -13,12 +13,12 @@ import { loginStateAtom } from '@/stores/atoms/loginStateAtom';
 import { selectedDateAtom } from '@/stores/atoms/selectedDateAtom';
 import { impossiblePullUpAtom } from '@/stores/atoms/workoutDataAtom';
 import { PlanType } from '@/types/plan';
-import { checkPastDate } from '@/utils/date';
+import { checkAfterDate } from '@/utils/date';
 
 export const PlanButtons = () => {
   const selectedDate = useAtomValue(selectedDateAtom);
   const isLoggedIn = useAtomValue(loginStateAtom);
-  const isPastDate = checkPastDate(selectedDate);
+  const isAfterDate = checkAfterDate(selectedDate);
   const [messageApi, contextHolder] = message.useMessage();
   const userImpossiblePullUps = useAtomValue(impossiblePullUpAtom);
   const isAllMaster = userImpossiblePullUps.length === 0;
@@ -27,7 +27,7 @@ export const PlanButtons = () => {
     if (!isLoggedIn) {
       return ROUTE_PATH.login;
     }
-    if (isPastDate || (planType === PLAN_TYPE.master && isAllMaster)) {
+    if (!isAfterDate || (planType === PLAN_TYPE.master && isAllMaster)) {
       return '';
     }
 
@@ -35,10 +35,10 @@ export const PlanButtons = () => {
   };
 
   const handlePlanButtonClick = () => {
-    if (isPastDate) {
+    if (!isAfterDate) {
       messageApi.open({
         ...WARNING_MESSAGE_OPTION,
-        content: PLAN_MESSAGE.pastDate,
+        content: PLAN_MESSAGE.afterDate,
       });
     }
   };

--- a/src/pages/Plan/PlanButtons/index.tsx
+++ b/src/pages/Plan/PlanButtons/index.tsx
@@ -16,7 +16,7 @@ export const PlanButtons = () => {
   const isPastDate = checkPastDate(selectedDate);
   const [messageApi, contextHolder] = message.useMessage();
   const userImpossiblePullUps = useAtomValue(impossiblePullUpAtom);
-  const isAllMaster = userImpossiblePullUps.length <= 0;
+  const isAllMaster = userImpossiblePullUps.length === 0;
 
   const getPlanLink = (planType: PlanType) => {
     if (!isLoggedIn) {
@@ -47,7 +47,7 @@ export const PlanButtons = () => {
   const masterPlanLink = getPlanLink(PLAN_TYPE.master);
 
   const handleMasterButtonClick = () => {
-    if (userImpossiblePullUps.length <= 0) {
+    if (isAllMaster) {
       messageApi.open({
         type: 'warning',
         content: `모든 풀업 운동이 가능해서 마스터 할 동작이 없어요! 대신, [${PLAN_TYPE_KR.strength}]을 만들 수 있어요.`,

--- a/src/pages/Plan/PlanButtons/index.tsx
+++ b/src/pages/Plan/PlanButtons/index.tsx
@@ -2,8 +2,13 @@ import { message } from 'antd';
 import { useAtomValue } from 'jotai';
 import { Link } from 'react-router-dom';
 
-import { PLAN_MESSAGE, PLAN_TYPE, PLAN_TYPE_KR, ROUTE_PATH } from '@/constants';
-import { WarningIcon } from '@/icons/WarningIcon';
+import {
+  PLAN_MESSAGE,
+  PLAN_TYPE,
+  PLAN_TYPE_KR,
+  ROUTE_PATH,
+  WARNING_MESSAGE_OPTION,
+} from '@/constants';
 import { loginStateAtom } from '@/stores/atoms/loginStateAtom';
 import { selectedDateAtom } from '@/stores/atoms/selectedDateAtom';
 import { impossiblePullUpAtom } from '@/stores/atoms/workoutDataAtom';
@@ -32,13 +37,8 @@ export const PlanButtons = () => {
   const handlePlanButtonClick = () => {
     if (isPastDate) {
       messageApi.open({
-        type: 'warning',
+        ...WARNING_MESSAGE_OPTION,
         content: PLAN_MESSAGE.pastDate,
-        duration: 2,
-        style: {
-          marginTop: '75vh',
-        },
-        icon: WarningIcon(),
       });
     }
   };
@@ -49,13 +49,8 @@ export const PlanButtons = () => {
   const handleMasterButtonClick = () => {
     if (isAllMaster) {
       messageApi.open({
-        type: 'warning',
-        content: `모든 풀업 운동이 가능해서 마스터 할 동작이 없어요! 대신, [${PLAN_TYPE_KR.strength}]을 만들 수 있어요.`,
-        duration: 5,
-        style: {
-          marginTop: '75vh',
-        },
-        icon: WarningIcon(),
+        ...WARNING_MESSAGE_OPTION,
+        content: PLAN_MESSAGE.allMaster,
       });
 
       return;

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -16,6 +16,13 @@ export const checkPastDateTime = (date: string, time: string): boolean => {
   return inputDate.isBefore(now, 'minute');
 };
 
+export const checkAfterDate = (date: string): boolean => {
+  const inputDate = dayjs(date);
+  const today = dayjs();
+
+  return inputDate.isAfter(today, 'day');
+};
+
 export const convertToUTCDate = (dateString: string, timeString: string) => {
   const [year, month, day] = dateString.split('-').map(Number);
   const [hour, minute] = timeString.split(':').map(Number);

--- a/src/utils/getImpossiblePullUps.ts
+++ b/src/utils/getImpossiblePullUps.ts
@@ -1,5 +1,7 @@
-export const getImpossiblePullUps = (possiblePullUps: number[]) => {
-  const allPullUps = [1, 2, 3, 4, 5, 6, 7, 8];
+import { StepIdForWorkout } from '@/types/workout';
+
+export const getImpossiblePullUps = (possiblePullUps: StepIdForWorkout[]) => {
+  const allPullUps: StepIdForWorkout[] = [1, 2, 3, 4, 5, 6, 7, 8];
 
   return allPullUps.filter((pullUp) => {
     return !possiblePullUps.includes(pullUp);


### PR DESCRIPTION
## Issues
- Issue number #105 

## Tasks Done 
- [x] NewPlan 페이지 내 컴포넌트 분리
- [x] NewPlan 페이지의 문자열 상수 처리

## Description
### NewPlan 페이지 리팩터링
- **isAllMaster** 변수의 평가식에서 **userImpossiblePullUps**는 배열이므로 length가 0보다 크거나 같기 때문에, 부등호를 삭제했습니다.
  - **handleMasterButtonClick** 함수에서 조건식이 중복되므로 대신 **isAllMaster** 변수를 사용했습니다.
- **pullUpList** 변수의 값인 **possiblePullUps**과 **impossiblePullUps**의 타입을 일치 시켰습니다.
- `NewPlan`의 코드의 양이 많아서, form 태그 내 UI들을 `PlanNameSection`, `WorkoutTimeSection`, `WorkoutTableSection` 컴포넌트로 분리했습니다.
- `NewPlan` 페이지의 문자열들을 `constants/plan` 파일에서 상수로 선언하여 사용하도록 수정했습니다.
- FE-BE 인터페이스 정의서와 plans POST API 실제 동작에서 오늘 날짜 이후부터 플랜을 생성할 수 있으므로, **isPastDate** 변수를 **isAfterDate** 변수로 변경했습니다.
  - Dayis의 **isAfter** 함수를 사용하여 오늘 이후 날짜인지 판별하고, 그렇지 않은 경우에는 플랜을 생성하지 않고 경고 메시지가 나타나도록 수정했습니다. 

### 기타 리팩터링
- 회원탈퇴 페이지에서 나간 경우 **isTimerActive** 상태가 false로 초기화되도록 **useEffect**의 cleanup 함수를 추가했습니다.
- 경고 메시지들의 옵션과 성공 메시지들의 옵션이 같으므로, 상수 처리하여 재활용하도록 수정했습니다.